### PR TITLE
Fix release workflow version handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,9 @@ jobs:
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             VERSION="${{ github.event.inputs.version }}"
           else
-            VERSION=${GITHUB_REF#refs/tags/}
+            # Get the tag and remove the 'v' prefix if present
+            TAG=${GITHUB_REF#refs/tags/}
+            VERSION=${TAG#v}
           fi
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           
@@ -156,7 +158,8 @@ jobs:
 
       - name: "Extract version"
         run: |
-          VERSION=${GITHUB_REF#refs/tags/}
+          TAG=${GITHUB_REF#refs/tags/}
+          VERSION=${TAG#v}
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: "Generate release notes"


### PR DESCRIPTION
## Summary
- Fix version parsing in release workflow to strip 'v' prefix from git tags
- Ensures proper semantic versioning for .NET build process

## Problem
The release workflow was failing because it was passing 'v1.0.0-beta1' as the version to dotnet, which expects '1.0.0-beta1' (without the 'v' prefix).

## Solution
- Strip the 'v' prefix when extracting version from git tags
- Keep version handling consistent across all workflow steps

This fix will allow the release pipeline to build and publish binaries correctly.