### PR TITLE
Fix install scripts with pre-release, dry-run, and uninstall support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,12 +171,12 @@ jobs:
           
           ### Linux/macOS
           \`\`\`bash
-          curl -sSL https://raw.githubusercontent.com/stannardlabs/kit-cli/dev/install.sh | bash
+          curl -sSL https://raw.githubusercontent.com/${{ github.repository }}/dev/install.sh | bash
           \`\`\`
           
           ### Windows (PowerShell)
           \`\`\`powershell
-          iwr -useb https://raw.githubusercontent.com/stannardlabs/kit-cli/dev/install.ps1 | iex
+          iwr -useb https://raw.githubusercontent.com/${{ github.repository }}/dev/install.ps1 | iex
           \`\`\`
           
           ## Update Existing Installation

--- a/README.md
+++ b/README.md
@@ -19,12 +19,51 @@ A high-performance command-line interface for Kit (formerly ConvertKit) email ma
 
 ## Installation
 
-### Prerequisites
+### Quick Install
 
-- .NET 9 SDK
-- Kit API key (get from your Kit account settings)
+#### Linux/macOS
+```bash
+# Install latest stable release
+curl -sSL https://raw.githubusercontent.com/Aaronontheweb/kit-cli/dev/install.sh | bash
+
+# Or install latest beta/pre-release
+curl -sSL https://raw.githubusercontent.com/Aaronontheweb/kit-cli/dev/install.sh | bash -s -- --beta
+```
+
+#### Windows (PowerShell)
+```powershell
+# Install latest stable release
+iwr -useb https://raw.githubusercontent.com/Aaronontheweb/kit-cli/dev/install.ps1 | iex
+
+# Or install latest beta/pre-release with custom directory
+.\install.ps1 -Beta -InstallDir "C:\tools\kit"
+```
+
+### Advanced Installation Options
+
+#### Dry Run (test without installing)
+```bash
+# Linux/macOS
+curl -sSL https://raw.githubusercontent.com/Aaronontheweb/kit-cli/dev/install.sh | bash -s -- --dry-run
+
+# Windows
+iwr -useb https://raw.githubusercontent.com/Aaronontheweb/kit-cli/dev/install.ps1 | iex -DryRun
+```
+
+#### Uninstall
+```bash
+# Linux/macOS
+curl -sSL https://raw.githubusercontent.com/Aaronontheweb/kit-cli/dev/install.sh | bash -s -- --uninstall
+
+# Windows
+iwr -useb https://raw.githubusercontent.com/Aaronontheweb/kit-cli/dev/install.ps1 | iex -Uninstall
+```
 
 ### From Source
+
+Prerequisites:
+- .NET 9 SDK
+- Kit API key (get from your Kit account settings)
 
 ```bash
 # Clone the repository
@@ -32,7 +71,7 @@ git clone https://github.com/Aaronontheweb/kit-cli.git
 cd kit-cli
 
 # Build with AOT compilation
-dotnet publish -c Release /p:PublishAot=true -o ./publish
+dotnet publish src/KitCLI -c Release /p:PublishAot=true -o ./publish
 
 # Add to PATH (Linux/macOS)
 sudo ln -s $(pwd)/publish/kit /usr/local/bin/kit

--- a/install.ps1
+++ b/install.ps1
@@ -1,120 +1,401 @@
-# Kit CLI Installation Script for Windows
+# Kit CLI Installer for Windows
+#
+# Usage:
+#   iwr -useb https://raw.githubusercontent.com/Aaronontheweb/kit-cli/dev/install.ps1 | iex
+#
+# Or download and run:
+#   .\install.ps1
+#   .\install.ps1 -InstallDir "C:\custom\path"
+#   .\install.ps1 -DryRun
+#   .\install.ps1 -Beta
+#   .\install.ps1 -Uninstall
+#
 
 param(
-    [string]$InstallDir = "$env:LOCALAPPDATA\Programs\KitCLI"
+    [string]$InstallDir = "",
+    [switch]$Force,
+    [switch]$DryRun,
+    [switch]$Beta,
+    [switch]$Uninstall,
+    [switch]$Help
 )
 
 $ErrorActionPreference = "Stop"
 
-$repo = "Aaronontheweb/kit-cli"
-$binaryName = "kit.exe"
-
-Write-Host "Installing Kit CLI..." -ForegroundColor Cyan
-
-# Detect architecture
-$arch = if ([Environment]::Is64BitOperatingSystem) { "x64" } else { "x86" }
-$platform = "win-$arch"
-
-# Create installation directory
-if (!(Test-Path $InstallDir)) {
-    Write-Host "Creating installation directory: $InstallDir"
-    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
-}
-
-# Get latest release
-Write-Host "Fetching latest release..."
-try {
-    $releases = Invoke-RestMethod -Uri "https://api.github.com/repos/$repo/releases/latest"
-    $asset = $releases.assets | Where-Object { $_.name -like "*$platform*" } | Select-Object -First 1
-    
-    if ($null -eq $asset) {
-        Write-Host "No pre-built binary found for $platform" -ForegroundColor Yellow
-        Write-Host "Attempting to build from source..."
-        
-        # Check if .NET SDK is installed
-        $dotnet = Get-Command dotnet -ErrorAction SilentlyContinue
-        if ($null -eq $dotnet) {
-            Write-Host ".NET SDK is not installed. Please install .NET 9 SDK first." -ForegroundColor Red
-            Write-Host "Visit: https://dotnet.microsoft.com/download/dotnet/9.0"
-            exit 1
-        }
-        
-        # Clone and build
-        $tempDir = New-TemporaryFile | ForEach-Object { Remove-Item $_; New-Item -ItemType Directory -Path $_ }
-        Push-Location $tempDir
-        
-        try {
-            Write-Host "Cloning repository..."
-            git clone --depth 1 "https://github.com/$repo.git" kit-cli
-            Set-Location kit-cli\src\KitCLI
-            
-            Write-Host "Building Kit CLI..."
-            dotnet publish -c Release /p:PublishAot=true /p:PublishSingleFile=true --self-contained -r $platform
-            
-            $binaryPath = Get-ChildItem -Path . -Filter "kit.exe" -Recurse | Where-Object { $_.DirectoryName -like "*publish*" } | Select-Object -First 1
-            
-            if ($null -eq $binaryPath) {
-                throw "Failed to build Kit CLI"
-            }
-            
-            Copy-Item $binaryPath.FullName "$InstallDir\$binaryName" -Force
-        }
-        finally {
-            Pop-Location
-            Remove-Item $tempDir -Recurse -Force
-        }
-    }
-    else {
-        # Download pre-built binary
-        $downloadUrl = $asset.browser_download_url
-        Write-Host "Downloading Kit CLI from $downloadUrl..."
-        
-        $tempFile = [System.IO.Path]::GetTempFileName()
-        Invoke-WebRequest -Uri $downloadUrl -OutFile "$tempFile.zip"
-        
-        # Extract
-        Write-Host "Extracting..."
-        Expand-Archive -Path "$tempFile.zip" -DestinationPath $InstallDir -Force
-        
-        # Clean up
-        Remove-Item "$tempFile.zip"
-    }
-}
-catch {
-    Write-Host "Error during installation: $_" -ForegroundColor Red
-    exit 1
-}
-
-# Add to PATH if not already there
-$userPath = [Environment]::GetEnvironmentVariable("Path", "User")
-if ($userPath -notlike "*$InstallDir*") {
-    Write-Host "Adding Kit CLI to PATH..."
-    $newPath = "$userPath;$InstallDir"
-    [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
-    $env:Path = "$env:Path;$InstallDir"
-    
-    Write-Host "Kit CLI has been added to your PATH." -ForegroundColor Green
-    Write-Host "You may need to restart your terminal for the changes to take effect." -ForegroundColor Yellow
-}
-
-# Verify installation
-$kitPath = Join-Path $InstallDir $binaryName
-if (Test-Path $kitPath) {
-    Write-Host "`nKit CLI installed successfully!" -ForegroundColor Green
+# Show help if requested
+if ($Help) {
+    Write-Host "Kit CLI Installer for Windows"
     Write-Host ""
+    Write-Host "Usage: .\install.ps1 [OPTIONS]"
+    Write-Host ""
+    Write-Host "Options:"
+    Write-Host "  -InstallDir <path>  Custom installation directory"
+    Write-Host "  -Force              Skip confirmation prompts"
+    Write-Host "  -DryRun             Download and verify but don't install"
+    Write-Host "  -Beta               Include beta/pre-release versions"
+    Write-Host "  -Uninstall          Remove Kit CLI and optionally config"
+    Write-Host "  -Help               Show this help message"
+    Write-Host ""
+    Write-Host "Examples:"
+    Write-Host "  # Install latest stable release"
+    Write-Host "  .\install.ps1"
+    Write-Host ""
+    Write-Host "  # Install latest beta"
+    Write-Host "  .\install.ps1 -Beta"
+    Write-Host ""
+    Write-Host "  # Dry run to test installation"
+    Write-Host "  .\install.ps1 -DryRun"
+    Write-Host ""
+    Write-Host "  # Install to custom directory"
+    Write-Host "  .\install.ps1 -InstallDir 'C:\tools\kit'"
+    Write-Host ""
+    Write-Host "  # Uninstall"
+    Write-Host "  .\install.ps1 -Uninstall"
+    exit 0
+}
+
+# Configuration
+$RepoOwner = "Aaronontheweb"
+$RepoName = "kit-cli"
+$BinaryName = "kit.exe"
+$ConfigDir = "$env:APPDATA\kit-cli"
+
+# Set default install directory if not provided
+if ([string]::IsNullOrEmpty($InstallDir)) {
+    $InstallDir = "$env:LOCALAPPDATA\Programs\kit"
+}
+
+# Helper functions
+function Write-Info { Write-Host "[INFO] $args" -ForegroundColor Green }
+function Write-Warn { Write-Host "[WARN] $args" -ForegroundColor Yellow }
+function Write-Error { Write-Host "[ERROR] $args" -ForegroundColor Red; exit 1 }
+
+function Get-Platform {
+    $arch = if ([Environment]::Is64BitOperatingSystem) { "x64" } else { "x86" }
+    return "win-$arch"
+}
+
+function Get-LatestVersion {
+    param([bool]$IncludeBeta = $false)
     
-    # Try to run version command
+    $headers = @{
+        "User-Agent" = "kit-cli-installer"
+    }
+    
     try {
-        & $kitPath --version
+        if ($IncludeBeta) {
+            Write-Info "Fetching latest release information (including pre-releases)..."
+            $apiUrl = "https://api.github.com/repos/$RepoOwner/$RepoName/releases"
+            $releases = Invoke-RestMethod -Uri $apiUrl -Headers $headers
+            
+            if ($releases -and $releases.Count -gt 0) {
+                # Get the first release (most recent)
+                return $releases[0].tag_name
+            }
+        } else {
+            Write-Info "Fetching latest stable release information..."
+            $apiUrl = "https://api.github.com/repos/$RepoOwner/$RepoName/releases/latest"
+            
+            try {
+                $release = Invoke-RestMethod -Uri $apiUrl -Headers $headers
+                return $release.tag_name
+            } catch {
+                # No stable release, try pre-releases
+                Write-Warn "No stable release found, trying pre-releases..."
+                return Get-LatestVersion -IncludeBeta $true
+            }
+        }
     }
     catch {
-        Write-Host "Version: (run 'kit --version' to check)" -ForegroundColor Gray
+        Write-Error "Failed to fetch release information: $_"
+    }
+    
+    Write-Error "Could not determine latest version"
+}
+
+function Install-Binary {
+    param(
+        [string]$Version,
+        [string]$Platform,
+        [bool]$IsDryRun = $false
+    )
+    
+    # Remove 'v' prefix if present for the filename
+    $versionClean = $Version -replace '^v', ''
+    
+    # Build download URL
+    $downloadUrl = "https://github.com/$RepoOwner/$RepoName/releases/download/$Version/$($BinaryName -replace '\.exe$', '')-$versionClean-$Platform.zip"
+    
+    $tempDir = New-TemporaryFile | ForEach-Object { Remove-Item $_; New-Item -ItemType Directory -Path $_ }
+    $tempFile = Join-Path $tempDir "$BinaryName.zip"
+    
+    Write-Info "Downloading Kit CLI $Version for $Platform..."
+    Write-Info "URL: $downloadUrl"
+    
+    try {
+        # Download with progress
+        $ProgressPreference = 'Continue'
+        Invoke-WebRequest -Uri $downloadUrl -OutFile $tempFile -UseBasicParsing
+    }
+    catch {
+        Remove-Item -Path $tempDir -Recurse -Force
+        Write-Error "Failed to download from: $downloadUrl`n$_"
+    }
+    
+    Write-Info "Extracting binary..."
+    try {
+        Expand-Archive -Path $tempFile -DestinationPath $tempDir -Force
+    }
+    catch {
+        Remove-Item -Path $tempDir -Recurse -Force
+        Write-Error "Failed to extract archive: $_"
+    }
+    
+    # Find the binary
+    $binaryPath = Join-Path $tempDir $BinaryName
+    if (!(Test-Path $binaryPath)) {
+        # Binary might be in a subdirectory
+        $binaryPath = Get-ChildItem -Path $tempDir -Filter $BinaryName -Recurse | Select-Object -First 1 -ExpandProperty FullName
+        
+        if (!$binaryPath -or !(Test-Path $binaryPath)) {
+            Remove-Item -Path $tempDir -Recurse -Force
+            Write-Error "Binary not found in archive"
+        }
+    }
+    
+    if ($IsDryRun) {
+        Write-Info "DRY-RUN: Would install binary to $InstallDir\$BinaryName"
+        Write-Info "DRY-RUN: Binary found at: $binaryPath"
+        
+        # Test the binary
+        try {
+            $testOutput = & $binaryPath --version 2>&1
+            Write-Info "DRY-RUN: Binary test successful: $testOutput"
+        }
+        catch {
+            Write-Warn "DRY-RUN: Binary test failed - may not be compatible with this system"
+        }
+        
+        Remove-Item -Path $tempDir -Recurse -Force
+        return
+    }
+    
+    # Create install directory if it doesn't exist
+    if (!(Test-Path $InstallDir)) {
+        New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+    }
+    
+    # Move binary to install location
+    Write-Info "Installing binary to $InstallDir\$BinaryName..."
+    Move-Item -Path $binaryPath -Destination "$InstallDir\$BinaryName" -Force
+    
+    # Clean up
+    Remove-Item -Path $tempDir -Recurse -Force
+}
+
+function Test-InPath {
+    $paths = $env:PATH -split ';'
+    return $paths -contains $InstallDir
+}
+
+function Add-ToPath {
+    if (!(Test-InPath)) {
+        Write-Warn "$InstallDir is not in your PATH"
+        Write-Host ""
+        
+        if (!$DryRun) {
+            Write-Host "Would you like to add it to your PATH? [Y/n]: " -NoNewline
+            $response = Read-Host
+            
+            if ($response -eq '' -or $response -match '^[Yy]') {
+                # Add to user PATH
+                $userPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+                if ($userPath) {
+                    $newPath = "$userPath;$InstallDir"
+                } else {
+                    $newPath = $InstallDir
+                }
+                
+                [Environment]::SetEnvironmentVariable("PATH", $newPath, "User")
+                $env:PATH = "$env:PATH;$InstallDir"
+                
+                Write-Info "Added $InstallDir to PATH"
+                Write-Info "You may need to restart your terminal for changes to take effect"
+            } else {
+                Write-Host ""
+                Write-Host "To add manually, run:"
+                Write-Host '  [Environment]::SetEnvironmentVariable("PATH", "$env:PATH;' + $InstallDir + '", "User")'
+                Write-Host ""
+                Write-Host "Or use the full path to run the binary:"
+                Write-Host "  $InstallDir\$BinaryName"
+            }
+        }
+    } else {
+        Write-Info "✓ $InstallDir is already in PATH"
+    }
+}
+
+function Uninstall-KitCLI {
+    Write-Host "===================================" -ForegroundColor Cyan
+    Write-Host "  Kit CLI Uninstaller" -ForegroundColor Cyan
+    Write-Host "===================================" -ForegroundColor Cyan
+    Write-Host ""
+    
+    $removedSomething = $false
+    $binaryPath = Join-Path $InstallDir $BinaryName
+    
+    # Remove binary
+    if (Test-Path $binaryPath) {
+        Write-Info "Found Kit CLI at: $binaryPath"
+        
+        # Get version before removal
+        try {
+            $version = & $binaryPath --version 2>&1 | Select-Object -First 1
+            Write-Info "Version: $version"
+        }
+        catch {
+            # Ignore version check errors
+        }
+        
+        Remove-Item -Path $binaryPath -Force
+        Write-Info "Binary removed successfully"
+        $removedSomething = $true
+    } else {
+        Write-Warn "Binary not found at $binaryPath"
+    }
+    
+    # Ask about config removal
+    if (Test-Path $ConfigDir) {
+        Write-Host ""
+        Write-Host "Remove configuration directory ${ConfigDir}? [y/N]: " -NoNewline
+        $response = Read-Host
+        
+        if ($response -match '^[Yy]') {
+            Remove-Item -Path $ConfigDir -Recurse -Force
+            Write-Info "Configuration directory removed"
+            $removedSomething = $true
+        } else {
+            Write-Info "Configuration directory preserved"
+        }
+    }
+    
+    # Check if install directory is empty
+    if ((Test-Path $InstallDir) -and (Get-ChildItem $InstallDir).Count -eq 0) {
+        Write-Host ""
+        Write-Host "Remove empty installation directory ${InstallDir}? [y/N]: " -NoNewline
+        $response = Read-Host
+        
+        if ($response -match '^[Yy]') {
+            Remove-Item -Path $InstallDir -Force
+            Write-Info "Installation directory removed"
+        }
+    }
+    
+    # Remove from PATH if present
+    if (Test-InPath) {
+        Write-Host ""
+        Write-Host "Remove $InstallDir from PATH? [y/N]: " -NoNewline
+        $response = Read-Host
+        
+        if ($response -match '^[Yy]') {
+            $userPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+            $paths = $userPath -split ';' | Where-Object { $_ -ne $InstallDir }
+            $newPath = $paths -join ';'
+            [Environment]::SetEnvironmentVariable("PATH", $newPath, "User")
+            Write-Info "Removed from PATH"
+        }
     }
     
     Write-Host ""
-    Write-Host "Get started with: kit --help" -ForegroundColor Cyan
+    if ($removedSomething) {
+        Write-Info "Uninstall completed successfully"
+    } else {
+        Write-Warn "Nothing was removed - Kit CLI may not have been installed"
+    }
 }
-else {
-    Write-Host "Installation may have failed. Please check $InstallDir" -ForegroundColor Red
-    exit 1
+
+# Main execution
+if ($Uninstall) {
+    Uninstall-KitCLI
+    exit 0
+}
+
+Write-Host "===================================" -ForegroundColor Cyan
+Write-Host "  Kit CLI Installer" -ForegroundColor Cyan
+Write-Host "===================================" -ForegroundColor Cyan
+Write-Host ""
+
+if ($DryRun) {
+    Write-Warn "Running in DRY-RUN mode - will download but not install"
+    Write-Host ""
+}
+
+# Detect platform
+$platform = Get-Platform
+Write-Info "Detected platform: $platform"
+
+# Get latest version
+$version = Get-LatestVersion -IncludeBeta $Beta
+Write-Info "Latest version: $version"
+
+if ($Beta -and $version -match "(beta|rc|alpha|preview)") {
+    Write-Warn "Installing pre-release version: $version"
+}
+
+# Check if already installed
+$existingBinary = Join-Path $InstallDir $BinaryName
+if (Test-Path $existingBinary) {
+    try {
+        $currentVersion = & $existingBinary --version 2>&1 | Select-Object -First 1
+        Write-Warn "Existing installation found: $currentVersion"
+    }
+    catch {
+        Write-Warn "Existing installation found (version unknown)"
+    }
+    
+    if (!$DryRun -and !$Force) {
+        Write-Host "Do you want to overwrite it? [y/N]: " -NoNewline
+        $response = Read-Host
+        
+        if ($response -notmatch '^[Yy]') {
+            Write-Host "Installation cancelled"
+            exit 0
+        }
+    }
+}
+
+# Install binary
+Install-Binary -Version $version -Platform $platform -IsDryRun $DryRun
+
+if ($DryRun) {
+    Write-Host ""
+    Write-Info "DRY-RUN complete! No changes were made to your system."
+    Write-Info "To actually install, run without -DryRun flag"
+} else {
+    # Verify installation
+    $installedBinary = Join-Path $InstallDir $BinaryName
+    if (Test-Path $installedBinary) {
+        try {
+            $installedVersion = & $installedBinary --version 2>&1 | Select-Object -First 1
+            Write-Info "✓ Successfully installed Kit CLI $version"
+        }
+        catch {
+            Write-Error "Installation verification failed"
+        }
+    } else {
+        Write-Error "Installation failed - binary not found"
+    }
+    
+    # Check PATH
+    Add-ToPath
+    
+    Write-Host ""
+    Write-Host "Installation complete! 🎉" -ForegroundColor Green
+    Write-Host ""
+    Write-Host "To get started:"
+    Write-Host "  kit config set --api-key YOUR_API_KEY"
+    Write-Host "  kit --help"
+    Write-Host ""
+    Write-Host "To check for updates:"
+    Write-Host "  kit update"
 }

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,27 @@
 #!/usr/bin/env bash
+#
+# Kit CLI Installer
+# 
+# Usage:
+#   curl -sSL https://raw.githubusercontent.com/Aaronontheweb/kit-cli/dev/install.sh | bash
+#   wget -qO- https://raw.githubusercontent.com/Aaronontheweb/kit-cli/dev/install.sh | bash
+#
+# Or download and run:
+#   ./install.sh
+#   ./install.sh --dry-run
+#   ./install.sh --beta
+#   ./install.sh --uninstall
+#   INSTALL_DIR=/custom/path ./install.sh
+#
 
 set -e
 
-REPO="Aaronontheweb/kit-cli"
-INSTALL_DIR="/usr/local/bin"
+# Configuration
+REPO_OWNER="Aaronontheweb"
+REPO_NAME="kit-cli"
 BINARY_NAME="kit"
+INSTALL_DIR="${INSTALL_DIR:-${HOME}/.local/bin}"
+CONFIG_DIR="${HOME}/.config/kit-cli"
 
 # Colors for output
 RED='\033[0;31m'
@@ -12,109 +29,360 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-echo "Installing Kit CLI..."
+# Helper functions
+info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+error() { echo -e "${RED}[ERROR]${NC} $1"; exit 1; }
 
-# Detect OS and architecture
-OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-ARCH=$(uname -m)
-
-case "$OS" in
-    linux*)
-        PLATFORM="linux"
-        ;;
-    darwin*)
-        PLATFORM="osx"
-        ;;
-    *)
-        echo -e "${RED}Unsupported operating system: $OS${NC}"
-        exit 1
-        ;;
-esac
-
-case "$ARCH" in
-    x86_64|amd64)
-        ARCH="x64"
-        ;;
-    arm64|aarch64)
-        ARCH="arm64"
-        ;;
-    *)
-        echo -e "${RED}Unsupported architecture: $ARCH${NC}"
-        exit 1
-        ;;
-esac
-
-RELEASE_TAG="$PLATFORM-$ARCH"
-
-# Get latest release URL
-echo "Fetching latest release..."
-LATEST_RELEASE=$(curl -s "https://api.github.com/repos/$REPO/releases/latest" | grep browser_download_url | grep "$RELEASE_TAG" | cut -d '"' -f 4)
-
-if [ -z "$LATEST_RELEASE" ]; then
-    echo -e "${YELLOW}No pre-built binary found for $PLATFORM-$ARCH${NC}"
-    echo "Building from source..."
+# Detect OS and Architecture
+detect_platform() {
+    local os arch
     
-    # Check if .NET SDK is installed
-    if ! command -v dotnet &> /dev/null; then
-        echo -e "${RED}.NET SDK is not installed. Please install .NET 9 SDK first.${NC}"
-        echo "Visit: https://dotnet.microsoft.com/download/dotnet/9.0"
-        exit 1
+    # Detect OS
+    case "$(uname -s)" in
+        Linux*)  os="linux" ;;
+        Darwin*) os="osx" ;;
+        MINGW*|MSYS*|CYGWIN*) 
+            error "Please use install.ps1 for Windows" ;;
+        *)       
+            error "Unsupported OS: $(uname -s)" ;;
+    esac
+    
+    # Detect Architecture
+    case "$(uname -m)" in
+        x86_64|amd64) arch="x64" ;;
+        aarch64|arm64) arch="arm64" ;;
+        armv7l) arch="arm" ;;
+        *) error "Unsupported architecture: $(uname -m)" ;;
+    esac
+    
+    echo "${os}-${arch}"
+}
+
+# Check for required tools
+check_requirements() {
+    local missing_tools=()
+    
+    command -v curl >/dev/null 2>&1 || missing_tools+=("curl")
+    command -v tar >/dev/null 2>&1 || missing_tools+=("tar")
+    
+    if [ ${#missing_tools[@]} -ne 0 ]; then
+        error "Missing required tools: ${missing_tools[*]}\nPlease install them and try again."
+    fi
+}
+
+# Get latest release version from GitHub
+get_latest_version() {
+    local include_prerelease="${1:-false}"
+    local api_url
+    
+    if [ "$include_prerelease" = true ]; then
+        # Get all releases and find the latest (including pre-releases)
+        api_url="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
+    else
+        # Get only the latest stable release
+        api_url="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest"
     fi
     
-    # Clone and build
-    TEMP_DIR=$(mktemp -d)
-    cd "$TEMP_DIR"
+    local response
+    response=$(curl -s "$api_url") || error "Failed to fetch release information"
     
-    echo "Cloning repository..."
-    git clone --depth 1 "https://github.com/$REPO.git" kit-cli
-    cd kit-cli/src/KitCLI
-    
-    echo "Building Kit CLI..."
-    dotnet publish -c Release /p:PublishAot=true /p:PublishSingleFile=true --self-contained -r "$PLATFORM-$ARCH"
-    
-    # Find the built binary
-    BINARY_PATH=$(find . -name kit -type f -path "*/publish/*" | head -1)
-    
-    if [ -z "$BINARY_PATH" ]; then
-        echo -e "${RED}Failed to build Kit CLI${NC}"
-        exit 1
+    # Extract version from tag_name
+    local version
+    if [ "$include_prerelease" = true ]; then
+        # Get the first release from the array (most recent)
+        version=$(echo "$response" | grep '"tag_name"' | head -1 | sed -E 's/.*"tag_name":\s*"([^"]+)".*/\1/')
+    else
+        version=$(echo "$response" | grep '"tag_name"' | head -1 | sed -E 's/.*"tag_name":\s*"([^"]+)".*/\1/')
     fi
-else
-    # Download pre-built binary
-    TEMP_DIR=$(mktemp -d)
-    cd "$TEMP_DIR"
     
-    echo "Downloading Kit CLI from $LATEST_RELEASE..."
-    curl -sL "$LATEST_RELEASE" -o kit.tar.gz
-    tar -xzf kit.tar.gz
-    BINARY_PATH="./kit"
-fi
+    if [ -z "$version" ]; then
+        if [ "$include_prerelease" = false ]; then
+            warn "No stable release found, trying pre-releases..."
+            version=$(get_latest_version true)
+        else
+            error "Could not determine latest version"
+        fi
+    fi
+    
+    echo "$version"
+}
 
-# Check if we need sudo for installation
-if [ -w "$INSTALL_DIR" ]; then
-    SUDO=""
-else
-    SUDO="sudo"
-    echo "Installation requires administrator privileges..."
-fi
+# Download and install binary
+install_binary() {
+    local version="$1"
+    local platform="$2"
+    local dry_run="$3"
+    
+    # Remove 'v' prefix if present for the filename
+    local version_clean="${version#v}"
+    
+    # Build download URL
+    local download_url="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${version}/${BINARY_NAME}-${version_clean}-${platform}.tar.gz"
+    local temp_dir
+    temp_dir=$(mktemp -d)
+    local temp_file="${temp_dir}/${BINARY_NAME}.tar.gz"
+    
+    info "Downloading ${BINARY_NAME} ${version} for ${platform}..."
+    
+    # Download with progress bar
+    if ! curl -L --progress-bar -o "$temp_file" "$download_url"; then
+        rm -rf "$temp_dir"
+        error "Failed to download from: $download_url"
+    fi
+    
+    info "Extracting binary..."
+    if ! tar -xzf "$temp_file" -C "$temp_dir"; then
+        rm -rf "$temp_dir"
+        error "Failed to extract archive"
+    fi
+    
+    # Find the binary
+    local binary_path="${temp_dir}/${BINARY_NAME}"
+    
+    if [ ! -f "$binary_path" ]; then
+        rm -rf "$temp_dir"
+        error "Binary not found in archive"
+    fi
+    
+    # Check if this is a dry run
+    if [ "$dry_run" = true ]; then
+        info "DRY-RUN: Would install binary to ${INSTALL_DIR}/${BINARY_NAME}"
+        info "DRY-RUN: Binary found at: $binary_path"
+        
+        # Test the binary
+        if "$binary_path" --version >/dev/null 2>&1; then
+            local test_version=$("$binary_path" --version 2>/dev/null | head -1)
+            info "DRY-RUN: Binary test successful: $test_version"
+        else
+            warn "DRY-RUN: Binary test failed - may not be compatible with this system"
+        fi
+        
+        rm -rf "$temp_dir"
+        return 0
+    fi
+    
+    # Create install directory if it doesn't exist
+    mkdir -p "$INSTALL_DIR"
+    
+    # Move binary to install location
+    info "Installing binary to ${INSTALL_DIR}/${BINARY_NAME}..."
+    mv "$binary_path" "${INSTALL_DIR}/${BINARY_NAME}"
+    chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
+    
+    # Clean up
+    rm -rf "$temp_dir"
+}
 
-# Install the binary
-echo "Installing to $INSTALL_DIR/$BINARY_NAME..."
-$SUDO mv "$BINARY_PATH" "$INSTALL_DIR/$BINARY_NAME"
-$SUDO chmod +x "$INSTALL_DIR/$BINARY_NAME"
+# Check if install directory is in PATH
+check_path() {
+    if [[ ":$PATH:" != *":$INSTALL_DIR:"* ]]; then
+        warn "${INSTALL_DIR} is not in your PATH"
+        echo ""
+        echo "Add the following line to your shell configuration file (.bashrc, .zshrc, etc.):"
+        echo "  export PATH=\"\$PATH:${INSTALL_DIR}\""
+        echo ""
+        echo "Then reload your shell configuration:"
+        echo "  source ~/.bashrc  # or ~/.zshrc"
+        echo ""
+        echo "Or use the full path to run the binary:"
+        echo "  ${INSTALL_DIR}/${BINARY_NAME}"
+    else
+        info "✓ ${INSTALL_DIR} is in PATH"
+    fi
+}
 
-# Clean up
-cd /
-rm -rf "$TEMP_DIR"
-
-# Verify installation
-if command -v kit &> /dev/null; then
-    echo -e "${GREEN}Kit CLI installed successfully!${NC}"
+# Uninstall Kit CLI
+uninstall_kit() {
+    echo "==================================="
+    echo "  Kit CLI Uninstaller"
+    echo "==================================="
     echo ""
-    kit --version
+    
+    local removed_something=false
+    local binary_path="${INSTALL_DIR}/${BINARY_NAME}"
+    
+    # Remove binary
+    if [ -f "$binary_path" ]; then
+        info "Found Kit CLI at: $binary_path"
+        
+        # Get version before removal
+        local version="unknown"
+        if "$binary_path" --version >/dev/null 2>&1; then
+            version=$("$binary_path" --version 2>/dev/null | head -1)
+            info "Version: $version"
+        fi
+        
+        rm "$binary_path" || error "Failed to remove binary"
+        info "Binary removed successfully"
+        removed_something=true
+    else
+        warn "Binary not found at $binary_path"
+    fi
+    
+    # Ask about config removal
+    if [ -d "$CONFIG_DIR" ]; then
+        echo ""
+        echo -n "Remove configuration directory $CONFIG_DIR? [y/N]: "
+        read -r response
+        if [[ "$response" =~ ^[Yy]$ ]]; then
+            rm -rf "$CONFIG_DIR" || error "Failed to remove configuration directory"
+            info "Configuration directory removed"
+            removed_something=true
+        else
+            info "Configuration directory preserved"
+        fi
+    fi
+    
     echo ""
-    echo "Get started with: kit --help"
-else
-    echo -e "${YELLOW}Kit CLI was installed to $INSTALL_DIR but is not in your PATH${NC}"
-    echo "Add $INSTALL_DIR to your PATH or use the full path: $INSTALL_DIR/$BINARY_NAME"
-fi
+    if [ "$removed_something" = true ]; then
+        info "Uninstall completed successfully"
+    else
+        warn "Nothing was removed - Kit CLI may not have been installed"
+    fi
+    
+    # Check if install directory is now empty and removable
+    if [ -d "$INSTALL_DIR" ] && [ -z "$(ls -A "$INSTALL_DIR" 2>/dev/null)" ]; then
+        echo ""
+        echo -n "Remove empty installation directory $INSTALL_DIR? [y/N]: "
+        read -r response
+        if [[ "$response" =~ ^[Yy]$ ]]; then
+            rmdir "$INSTALL_DIR" 2>/dev/null && info "Installation directory removed" || warn "Could not remove installation directory"
+        fi
+    fi
+}
+
+# Main installation flow
+main() {
+    # Parse command line arguments
+    local dry_run=false
+    local include_beta=false
+    local uninstall=false
+    
+    for arg in "$@"; do
+        case $arg in
+            --dry-run|--dry|-n)
+                dry_run=true
+                ;;
+            --beta|--pre|--prerelease)
+                include_beta=true
+                ;;
+            --uninstall|--remove)
+                uninstall=true
+                ;;
+            --help|-h)
+                echo "Kit CLI Installer"
+                echo ""
+                echo "Usage: $0 [OPTIONS]"
+                echo ""
+                echo "Options:"
+                echo "  --dry-run, -n       Download and verify but don't install"
+                echo "  --beta, --pre       Include beta/pre-release versions"
+                echo "  --uninstall         Remove Kit CLI and optionally config"
+                echo "  --help, -h          Show this help message"
+                echo ""
+                echo "Environment variables:"
+                echo "  INSTALL_DIR         Set custom installation directory (default: ~/.local/bin)"
+                echo ""
+                echo "Examples:"
+                echo "  # Install latest stable release"
+                echo "  curl -sSL https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/dev/install.sh | bash"
+                echo ""
+                echo "  # Install latest beta/pre-release"
+                echo "  curl -sSL https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/dev/install.sh | bash -s -- --beta"
+                echo ""
+                echo "  # Dry run to test installation"
+                echo "  curl -sSL https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/dev/install.sh | bash -s -- --dry-run"
+                echo ""
+                echo "  # Uninstall"
+                echo "  curl -sSL https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/dev/install.sh | bash -s -- --uninstall"
+                exit 0
+                ;;
+        esac
+    done
+    
+    # Handle uninstall
+    if [ "$uninstall" = true ]; then
+        uninstall_kit
+        exit 0
+    fi
+    
+    echo "==================================="
+    echo "  Kit CLI Installer"
+    echo "==================================="
+    echo ""
+    
+    if [ "$dry_run" = true ]; then
+        warn "Running in DRY-RUN mode - will download but not install"
+        echo ""
+    fi
+    
+    # Check requirements
+    check_requirements
+    
+    # Detect platform
+    local platform
+    platform=$(detect_platform)
+    info "Detected platform: ${platform}"
+    
+    # Get latest version
+    if [ "$include_beta" = true ]; then
+        info "Including pre-release versions..."
+    fi
+    
+    local version
+    version=$(get_latest_version "$include_beta")
+    info "Latest version: ${version}"
+    
+    if [ "$include_beta" = true ] && [[ "$version" =~ (beta|rc|alpha|preview) ]]; then
+        warn "Installing pre-release version: ${version}"
+    fi
+    
+    # Check if already installed
+    if [ -f "${INSTALL_DIR}/${BINARY_NAME}" ]; then
+        local current_version
+        current_version=$("${INSTALL_DIR}/${BINARY_NAME}" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
+        warn "Existing installation found (version: ${current_version})"
+        
+        if [ "$dry_run" = false ]; then
+            echo -n "Do you want to overwrite it? [y/N] "
+            read -r response
+            if [[ ! "$response" =~ ^[Yy]$ ]]; then
+                echo "Installation cancelled"
+                exit 0
+            fi
+        fi
+    fi
+    
+    # Install binary
+    install_binary "$version" "$platform" "$dry_run"
+    
+    if [ "$dry_run" = true ]; then
+        echo ""
+        info "DRY-RUN complete! No changes were made to your system."
+        info "To actually install, run without --dry-run flag"
+    else
+        # Verify installation
+        if "${INSTALL_DIR}/${BINARY_NAME}" --version >/dev/null 2>&1; then
+            info "✓ Successfully installed ${BINARY_NAME} ${version}"
+        else
+            error "Installation verification failed"
+        fi
+        
+        # Check PATH
+        check_path
+        
+        echo ""
+        echo "Installation complete! 🎉"
+        echo ""
+        echo "To get started:"
+        echo "  ${BINARY_NAME} config set --api-key YOUR_API_KEY"
+        echo "  ${BINARY_NAME} --help"
+        echo ""
+        echo "To check for updates:"
+        echo "  ${BINARY_NAME} update"
+    fi
+}
+
+# Run main function
+main "$@"

--- a/src/KitCLI/Program.cs
+++ b/src/KitCLI/Program.cs
@@ -56,7 +56,7 @@ if (args[0] == "--version" || args[0] == "-v")
     Console.WriteLine("Built with .NET 9 AOT compilation");
     Console.WriteLine();
     Console.WriteLine("Email marketing analytics for Kit (formerly ConvertKit)");
-    Console.WriteLine("https://github.com/stannardlabs/kit-cli");
+    Console.WriteLine("https://github.com/Aaronontheweb/kit-cli");
 
     // Wait for update check to complete and display if available
     var updateInfo = await updateCheckTask;
@@ -181,7 +181,7 @@ static void ShowHelp(string? versionInfo = null)
     Console.WriteLine("  kit subscriber list --status cancelled --export unsubscribed.csv");
     Console.WriteLine("  kit broadcast stats 12345");
     Console.WriteLine();
-    Console.WriteLine("For more information, visit: https://github.com/stannardlabs/kit-cli");
+    Console.WriteLine("For more information, visit: https://github.com/Aaronontheweb/kit-cli");
 }
 
 static async Task<int> RouteCommand(string[] args, bool isReadOnly = false, bool isVerbose = false, string? currentVersion = null)


### PR DESCRIPTION
## Summary
- Add support for installing pre-release versions with `--beta` flag
- Add `--dry-run` mode to test installation without making changes
- Add `--uninstall` functionality to remove Kit CLI and optionally configuration
- Fix repository URL inconsistencies across the codebase
- Update README with comprehensive installation instructions

## Changes
- **install.sh**: Complete rewrite matching freshdesk-cli pattern
  - `--beta/--pre/--prerelease` flags for beta versions
  - `--dry-run/-n` for testing
  - `--uninstall` for removal
  - Automatic fallback to pre-release if no stable version exists
  - Better error handling and user prompts

- **install.ps1**: PowerShell equivalent of all bash features
  - `-Beta` for pre-releases
  - `-DryRun` for testing
  - `-Uninstall` for removal
  - PATH management helpers

- **README.md**: Updated installation docs
  - Quick install commands for all platforms
  - Advanced options documented
  - Clear examples for each scenario

- **Repository URLs**: Fixed all references to use `Aaronontheweb/kit-cli`
  - Release workflow now uses dynamic repository reference
  - Program.cs updated to correct URLs

## Test Plan
- [x] Tested install.sh dry-run with beta flag
- [ ] Test actual installation on Linux/macOS
- [ ] Test PowerShell script on Windows
- [ ] Verify uninstall functionality
- [ ] Confirm v1.0.0-beta1 can be installed

🤖 Generated with [Claude Code](https://claude.ai/code)