### PR TITLE
fix: Remove non-existent CHANGELOG.md reference from release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,7 +229,7 @@ jobs:
           
           ## What's Changed
           
-          See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/${{ env.VERSION }}/CHANGELOG.md) for details.
+          Full changelog: https://github.com/${{ github.repository }}/compare/v1.0.0-beta...v${{ env.VERSION }}
           EOF
 
       - name: "Create GitHub Release"


### PR DESCRIPTION
## Summary
Removes reference to CHANGELOG.md from the release workflow since this file does not exist in the repository.

## Changes
- Replace CHANGELOG.md link with GitHub comparison link
- Shows changes between releases using GitHub's built-in comparison

🤖 Generated with [Claude Code](https://claude.ai/code)