### PR TITLE
fix: Improve version comparison logic and prepare 1.0.0 release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,3 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
     <Copyright>Copyright © $([System.DateTime]::Now.Year) Stannard Labs</Copyright>
@@ -7,7 +8,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>1.0.0-beta2</VersionPrefix>
+    <VersionPrefix>1.0.0</VersionPrefix>
     <PackageReleaseNotes>**New Features:**
 - **Profile Management**: Comprehensive profile system for managing multiple Kit accounts (#23)
 - **Forms Management**: Complete forms management commands for creating and managing opt-in forms (#16)
@@ -19,8 +20,10 @@
 - **Sequence/Automation Support**: Full support for email drip campaigns and automation workflows (#6)
 - **Segment Operations**: Advanced subscriber grouping and dynamic filtering (#5)
 - **Advanced Filtering**: Improved subscriber filtering capabilities (#4)
+- **Version Comparison**: Enhanced semantic versioning support for proper pre-release version handling
 
 **Bug Fixes:**
+- Fixed version comparison logic to properly handle pre-release versions (beta1 vs beta2)
 - Fixed NuGet publishing workflow configuration (#21)
 - Removed non-existent CHANGELOG.md reference from release notes (#20)
 - Fixed release workflow version handling (#18)
@@ -50,7 +53,6 @@
   </ItemGroup>
   <!-- NuGet .nupkg options -->
   <PropertyGroup>
-    <PackageReleaseNotes>Initial release of Kit CLI</PackageReleaseNotes>
     <PackageTags>kit;convertkit;email;marketing;cli</PackageTags>
     <PackageProjectUrl>https://github.com/Aaronontheweb/kit-cli</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,33 @@
+#### 1.0.0 August 15th 2025 ####
+
+**New Features:**
+- **Profile Management**: Comprehensive profile system for managing multiple Kit accounts (#23)
+- **Forms Management**: Complete forms management commands for creating and managing opt-in forms (#16)
+- **Self-Update Mechanism**: Built-in update capability to keep the CLI current (#17)
+- **Advanced Install Scripts**: Pre-release, dry-run, and uninstall support for easier deployment (#19)
+
+**Improvements:**
+- **Enhanced Error Handling**: Circuit breaker pattern and user-friendly error messages (#15)
+- **Sequence/Automation Support**: Full support for email drip campaigns and automation workflows (#6)
+- **Segment Operations**: Advanced subscriber grouping and dynamic filtering (#5)
+- **Advanced Filtering**: Improved subscriber filtering capabilities (#4)
+- **Version Comparison**: Enhanced semantic versioning support for proper pre-release version handling
+
+**Bug Fixes:**
+- Fixed version comparison logic to properly handle pre-release versions (beta1 vs beta2)
+- Fixed NuGet publishing workflow configuration (#21)
+- Removed non-existent CHANGELOG.md reference from release notes (#20)
+- Fixed release workflow version handling (#18)
+- Corrected license reference and removed obsolete changelog (#14)
+
+**Dependencies:**
+- Updated System.Text.Json to 9.0.8 (#11)
+- Updated Microsoft.Extensions.Http to 9.0.8 (#9)
+
+**Documentation:**
+- Comprehensive documentation and usage examples (#13)
+- Restructured GitHub Actions workflow (#8)
+
 #### 1.0.0-beta2 August 15th 2025 ####
 
 **New Features:**

--- a/scripts/bumpVersion.ps1
+++ b/scripts/bumpVersion.ps1
@@ -11,15 +11,43 @@ function UpdateVersionAndReleaseNotes {
     $xmlContent = New-Object XML
     $xmlContent.Load($XmlFilePath)
 
-    # Update VersionPrefix and PackageReleaseNotes
+    # Find the first PropertyGroup
+    $propertyGroup = $xmlContent.SelectSingleNode("//PropertyGroup[1]")
+    
+    if (-not $propertyGroup) {
+        throw "No PropertyGroup found in $XmlFilePath"
+    }
+
+    # Update or create VersionPrefix
     $versionPrefixElement = $xmlContent.SelectSingleNode("//VersionPrefix")
-    $versionPrefixElement.InnerText = $ReleaseNotesResult.Version
+    if ($versionPrefixElement) {
+        $versionPrefixElement.InnerText = $ReleaseNotesResult.Version
+    } else {
+        $versionPrefixElement = $xmlContent.CreateElement("VersionPrefix")
+        $versionPrefixElement.InnerText = $ReleaseNotesResult.Version
+        $propertyGroup.PrependChild($versionPrefixElement) | Out-Null
+    }
 
+    # Update or create PackageReleaseNotes
     $packageReleaseNotesElement = $xmlContent.SelectSingleNode("//PackageReleaseNotes")
-    $packageReleaseNotesElement.InnerText = $ReleaseNotesResult.ReleaseNotes
+    if ($packageReleaseNotesElement) {
+        $packageReleaseNotesElement.InnerText = $ReleaseNotesResult.ReleaseNotes
+    } else {
+        $packageReleaseNotesElement = $xmlContent.CreateElement("PackageReleaseNotes")
+        $packageReleaseNotesElement.InnerText = $ReleaseNotesResult.ReleaseNotes
+        $propertyGroup.AppendChild($packageReleaseNotesElement) | Out-Null
+    }
 
-    # Save the updated XML
-    $xmlContent.Save($XmlFilePath)
+    # Save the updated XML with proper formatting
+    $settings = New-Object System.Xml.XmlWriterSettings
+    $settings.Indent = $true
+    $settings.IndentChars = "  "
+    $settings.NewLineChars = "`n"
+    $settings.NewLineHandling = [System.Xml.NewLineHandling]::Replace
+    
+    $writer = [System.Xml.XmlWriter]::Create($XmlFilePath, $settings)
+    $xmlContent.Save($writer)
+    $writer.Close()
 }
 
 # Usage example:

--- a/src/KitCLI/Program.cs
+++ b/src/KitCLI/Program.cs
@@ -78,6 +78,7 @@ if (args[0] == "--test-aot")
     return 0;
 }
 
+
 if (args[0] == "--help" || args[0] == "-h")
 {
     ShowHelp(informationalVersion);

--- a/src/KitCLI/Services/UpdateService.cs
+++ b/src/KitCLI/Services/UpdateService.cs
@@ -128,31 +128,130 @@ public sealed class UpdateService
             latest = latest.TrimStart('v');
             current = current.TrimStart('v');
 
-            // Split into parts and parse
-            var latestParts = latest.Split('.').Select(int.Parse).ToArray();
-            var currentParts = current.Split('.').Select(int.Parse).ToArray();
+            // Parse semantic versions with pre-release support
+            var latestVersion = ParseSemanticVersion(latest);
+            var currentVersion = ParseSemanticVersion(current);
 
-            // Compare version parts
-            for (int i = 0; i < Math.Min(latestParts.Length, currentParts.Length); i++)
-            {
-                if (latestParts[i] > currentParts[i])
-                {
-                    return true;
-                }
-
-                if (latestParts[i] < currentParts[i])
-                {
-                    return false;
-                }
-            }
-
-            // If all compared parts are equal, newer version has more parts
-            return latestParts.Length > currentParts.Length;
+            return CompareSemanticVersions(latestVersion, currentVersion) > 0;
         }
         catch
         {
             return false;
         }
+    }
+
+    private static SemanticVersion ParseSemanticVersion(string version)
+    {
+        var parts = version.Split('-', 2);
+        var versionPart = parts[0];
+        var preRelease = parts.Length > 1 ? parts[1] : null;
+
+        var versionNumbers = versionPart.Split('.').Select(int.Parse).ToArray();
+        
+        // Ensure we have at least 3 parts (major.minor.patch)
+        Array.Resize(ref versionNumbers, Math.Max(3, versionNumbers.Length));
+
+        return new SemanticVersion
+        {
+            Major = versionNumbers[0],
+            Minor = versionNumbers[1],
+            Patch = versionNumbers[2],
+            PreRelease = preRelease
+        };
+    }
+
+    private static int CompareSemanticVersions(SemanticVersion a, SemanticVersion b)
+    {
+        // Compare major.minor.patch first
+        if (a.Major != b.Major) return a.Major.CompareTo(b.Major);
+        if (a.Minor != b.Minor) return a.Minor.CompareTo(b.Minor);
+        if (a.Patch != b.Patch) return a.Patch.CompareTo(b.Patch);
+
+        // If versions are equal, handle pre-release comparison
+        // No pre-release is greater than having pre-release
+        if (a.PreRelease == null && b.PreRelease != null) return 1;
+        if (a.PreRelease != null && b.PreRelease == null) return -1;
+        if (a.PreRelease == null && b.PreRelease == null) return 0;
+
+        // Both have pre-release, compare them
+        return ComparePreRelease(a.PreRelease!, b.PreRelease!);
+    }
+
+    private static int ComparePreRelease(string a, string b)
+    {
+        // Split pre-release into parts (e.g., "beta1" -> ["beta", "1"])
+        var aParts = SplitPreRelease(a);
+        var bParts = SplitPreRelease(b);
+
+        for (int i = 0; i < Math.Min(aParts.Length, bParts.Length); i++)
+        {
+            var result = ComparePreReleasePart(aParts[i], bParts[i]);
+            if (result != 0) return result;
+        }
+
+        // If all compared parts are equal, longer pre-release is greater
+        return aParts.Length.CompareTo(bParts.Length);
+    }
+
+    private static string[] SplitPreRelease(string preRelease)
+    {
+        var parts = new List<string>();
+        var current = "";
+
+        foreach (char c in preRelease)
+        {
+            if (char.IsDigit(c))
+            {
+                if (!string.IsNullOrEmpty(current) && !char.IsDigit(current[^1]))
+                {
+                    parts.Add(current);
+                    current = c.ToString();
+                }
+                else
+                {
+                    current += c;
+                }
+            }
+            else
+            {
+                if (!string.IsNullOrEmpty(current) && char.IsDigit(current[^1]))
+                {
+                    parts.Add(current);
+                    current = c.ToString();
+                }
+                else
+                {
+                    current += c;
+                }
+            }
+        }
+
+        if (!string.IsNullOrEmpty(current))
+        {
+            parts.Add(current);
+        }
+
+        return parts.ToArray();
+    }
+
+    private static int ComparePreReleasePart(string a, string b)
+    {
+        // If both are numeric, compare as numbers
+        if (int.TryParse(a, out int aNum) && int.TryParse(b, out int bNum))
+        {
+            return aNum.CompareTo(bNum);
+        }
+
+        // Otherwise compare as strings
+        return string.Compare(a, b, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed class SemanticVersion
+    {
+        public int Major { get; set; }
+        public int Minor { get; set; }
+        public int Patch { get; set; }
+        public string? PreRelease { get; set; }
     }
 
     public async Task<byte[]?> DownloadUpdateAsync(string downloadUrl, IProgress<double>? progress = null, CancellationToken cancellationToken = default)

--- a/src/KitCLI/Services/UpdateService.cs
+++ b/src/KitCLI/Services/UpdateService.cs
@@ -163,15 +163,37 @@ public sealed class UpdateService
     private static int CompareSemanticVersions(SemanticVersion a, SemanticVersion b)
     {
         // Compare major.minor.patch first
-        if (a.Major != b.Major) return a.Major.CompareTo(b.Major);
-        if (a.Minor != b.Minor) return a.Minor.CompareTo(b.Minor);
-        if (a.Patch != b.Patch) return a.Patch.CompareTo(b.Patch);
+        if (a.Major != b.Major)
+        {
+            return a.Major.CompareTo(b.Major);
+        }
+
+        if (a.Minor != b.Minor)
+        {
+            return a.Minor.CompareTo(b.Minor);
+        }
+
+        if (a.Patch != b.Patch)
+        {
+            return a.Patch.CompareTo(b.Patch);
+        }
 
         // If versions are equal, handle pre-release comparison
         // No pre-release is greater than having pre-release
-        if (a.PreRelease == null && b.PreRelease != null) return 1;
-        if (a.PreRelease != null && b.PreRelease == null) return -1;
-        if (a.PreRelease == null && b.PreRelease == null) return 0;
+        if (a.PreRelease == null && b.PreRelease != null)
+        {
+            return 1;
+        }
+
+        if (a.PreRelease != null && b.PreRelease == null)
+        {
+            return -1;
+        }
+
+        if (a.PreRelease == null && b.PreRelease == null)
+        {
+            return 0;
+        }
 
         // Both have pre-release, compare them
         return ComparePreRelease(a.PreRelease!, b.PreRelease!);
@@ -186,7 +208,10 @@ public sealed class UpdateService
         for (int i = 0; i < Math.Min(aParts.Length, bParts.Length); i++)
         {
             var result = ComparePreReleasePart(aParts[i], bParts[i]);
-            if (result != 0) return result;
+            if (result != 0)
+            {
+                return result;
+            }
         }
 
         // If all compared parts are equal, longer pre-release is greater

--- a/src/KitCLI/Services/UpdateService.cs
+++ b/src/KitCLI/Services/UpdateService.cs
@@ -147,7 +147,7 @@ public sealed class UpdateService
         var preRelease = parts.Length > 1 ? parts[1] : null;
 
         var versionNumbers = versionPart.Split('.').Select(int.Parse).ToArray();
-        
+
         // Ensure we have at least 3 parts (major.minor.patch)
         Array.Resize(ref versionNumbers, Math.Max(3, versionNumbers.Length));
 


### PR DESCRIPTION
## Summary
- Fixed version comparison logic to properly handle semantic versioning with pre-release identifiers
- Added comprehensive PowerShell build scripts for automated version and release note management
- Updated release notes for 1.0.0 stable release
- Enhanced update service to correctly compare beta versions (e.g., beta2 > beta1)

## Changes Made
- **Version Comparison**: Completely rewrote `IsNewerVersion` method in `UpdateService.cs` to support semantic versioning with pre-release handling
- **PowerShell Scripts**: Added `bumpVersion.ps1` and `getReleaseNotes.ps1` from freshdesk-cli for automated build processes
- **Release Notes**: Added comprehensive 1.0.0 release notes with all features and improvements
- **Build Integration**: Updated `Directory.Build.props` to version 1.0.0 with automated release note injection

## Test Plan
- [x] Version comparison logic tested with multiple scenarios (beta1 vs beta2, beta vs stable, numeric pre-release ordering)
- [x] Build script successfully parses release notes and updates project properties
- [x] All existing functionality preserved

## Impact
- Fixes update detection for pre-release versions
- Enables automated version management in CI/CD pipeline
- Prepares project for 1.0.0 stable release