### PR TITLE
fix: Prevent parallel test execution for console output tests

### DIFF
--- a/src/KitCLI.Tests/Helpers/OutputFormatterTests.cs
+++ b/src/KitCLI.Tests/Helpers/OutputFormatterTests.cs
@@ -4,6 +4,7 @@ using KitCLI.Models;
 
 namespace KitCLI.Tests.Helpers;
 
+[Collection("Console Output Tests")]
 public class OutputFormatterTests
 {
     [Fact]

--- a/src/KitCLI.Tests/Services/ErrorHandlerTests.cs
+++ b/src/KitCLI.Tests/Services/ErrorHandlerTests.cs
@@ -4,6 +4,7 @@ using KitCLI.Services;
 
 namespace KitCLI.Tests.Services;
 
+[Collection("Console Output Tests")]
 public class ErrorHandlerTests
 {
     [Theory]


### PR DESCRIPTION
## Summary
- Fixed race condition in tests that was causing intermittent failures in CI
- Tests that redirect Console.Out/Error now run sequentially to prevent interference

## Details
The  test was failing intermittently because it captures console output while other tests (like ConfigurationServiceTests) were writing to the console in parallel. 

Added  attribute to test classes that redirect console streams to ensure they don't run in parallel with other tests.

## Test Results
- All tests passing locally
- Ran the problematic test multiple times to verify it's no longer flaky