### PR TITLE
fix(api): Fetch subscriber tags via separate endpoint

### DIFF
--- a/src/KitCLI.Tests/Mocks/MockKitApiClient.cs
+++ b/src/KitCLI.Tests/Mocks/MockKitApiClient.cs
@@ -15,6 +15,7 @@ public sealed class MockKitApiClient : IKitApiClient
     public Func<string?, CancellationToken, IAsyncEnumerable<Subscriber>>? GetAllSubscribersAsyncFunc { get; set; }
     public Func<long, CancellationToken, Task<Subscriber?>>? GetSubscriberAsyncFunc { get; set; }
     public Func<string, CancellationToken, Task<Subscriber?>>? GetSubscriberByEmailAsyncFunc { get; set; }
+    public Func<long, CancellationToken, Task<Tag[]>>? GetSubscriberTagsAsyncFunc { get; set; }
 
     // Broadcasts
     public Func<int, string?, CancellationToken, Task<PaginatedResponse<Broadcast>>>? GetBroadcastsAsyncFunc { get; set; }
@@ -53,6 +54,7 @@ public sealed class MockKitApiClient : IKitApiClient
 
     // Pre-configured response data (simpler alternative to Funcs)
     public List<Subscriber> Subscribers { get; set; } = new();
+    public Dictionary<long, Tag[]> SubscriberTags { get; set; } = new();
     public List<Broadcast> Broadcasts { get; set; } = new();
     public Dictionary<long, BroadcastStats> BroadcastStats { get; set; } = new();
     public Dictionary<long, BroadcastClicksResponse> BroadcastClicks { get; set; } = new();
@@ -115,6 +117,16 @@ public sealed class MockKitApiClient : IKitApiClient
 
         return Task.FromResult(Subscribers.FirstOrDefault(s =>
             s.EmailAddress.Equals(email, StringComparison.OrdinalIgnoreCase)));
+    }
+
+    public Task<Tag[]> GetSubscriberTagsAsync(long subscriberId, CancellationToken cancellationToken = default)
+    {
+        if (GetSubscriberTagsAsyncFunc != null)
+        {
+            return GetSubscriberTagsAsyncFunc(subscriberId, cancellationToken);
+        }
+
+        return Task.FromResult(SubscriberTags.GetValueOrDefault(subscriberId) ?? []);
     }
 
     // Broadcasts

--- a/src/KitCLI/Commands/SubscriberCommands.cs
+++ b/src/KitCLI/Commands/SubscriberCommands.cs
@@ -113,6 +113,10 @@ public static class SubscriberCommands
             return 1;
         }
 
+        // Fetch tags separately (Kit V4 API returns tags via separate endpoint)
+        var tags = await client.GetSubscriberTagsAsync(subscriber.Id);
+        subscriber.Tags = tags;
+
         OutputFormatter.PrintSubscribers([subscriber], format);
         return 0;
     }

--- a/src/KitCLI/Services/KitApiClient.cs
+++ b/src/KitCLI/Services/KitApiClient.cs
@@ -21,6 +21,7 @@ public interface IKitApiClient
 
     Task<Subscriber?> GetSubscriberAsync(long id, CancellationToken cancellationToken = default);
     Task<Subscriber?> GetSubscriberByEmailAsync(string email, CancellationToken cancellationToken = default);
+    Task<Tag[]> GetSubscriberTagsAsync(long subscriberId, CancellationToken cancellationToken = default);
 
     // Broadcasts
     Task<PaginatedResponse<Broadcast>> GetBroadcastsAsync(
@@ -272,6 +273,23 @@ public sealed class KitApiClient : IKitApiClient, IDisposable
 
         return result?.Data.FirstOrDefault(s =>
             s.EmailAddress.Equals(email, StringComparison.OrdinalIgnoreCase));
+    }
+
+    public async Task<Tag[]> GetSubscriberTagsAsync(long subscriberId, CancellationToken cancellationToken = default)
+    {
+        var response = await _httpClient.GetAsync($"subscribers/{subscriberId}/tags", cancellationToken);
+
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return [];
+        }
+
+        response.EnsureSuccessStatusCode();
+
+        var json = await response.Content.ReadAsStringAsync(cancellationToken);
+        // Kit V4 API returns tags wrapped in {"tags": [...]}
+        var result = JsonSerializer.Deserialize(json, KitJsonContext.Default.TagsResponse);
+        return result?.Tags ?? [];
     }
 
     public async Task<PaginatedResponse<Broadcast>> GetBroadcastsAsync(


### PR DESCRIPTION
## Summary

Fixes #75 - Subscriber tags now display correctly when viewing individual subscribers.

### Problem

Kit V4 API returns subscriber tags via a separate endpoint (`/v4/subscribers/{id}/tags`) rather than inline with subscriber data. This caused the Tags column to always be empty.

### Solution

- Add `GetSubscriberTagsAsync` to `IKitApiClient` interface
- Implement the endpoint in `KitApiClient`
- Update `HandleGet` to fetch tags when viewing a single subscriber
- Update `MockKitApiClient` with test support

### Design Decision

Tags are only fetched when viewing a **single subscriber** (`kit subscriber get <id>`), not in list commands. This avoids N+1 API queries when listing many subscribers. If tag filtering in lists becomes important, we can add a `--with-tags` option later that explicitly opts into the additional API calls.

## Test plan

- [x] Build succeeds
- [x] All 109 tests pass
- [ ] CI passes