### PR TITLE
Release 1.1.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,19 +8,14 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>1.1.0</VersionPrefix>
-    <PackageReleaseNotes>**New Features:**
-- **Broadcast Analytics**: Added `kit broadcast analyze` command for detailed broadcast performance analysis with engagement metrics, deliverability tracking, and performance ratings (#72, #58)
-- **Comprehensive Help System**: Added `--help` flag support to all commands with usage examples and detailed descriptions (#27)
+    <VersionPrefix>1.1.1</VersionPrefix>
+    <PackageReleaseNotes>**Bug Fixes:**
+- **Broadcast Analytics**: Fixed broadcast stats parsing and added per-URL click tracking support for Kit V4 API (#80, #77)
+- **Subscriber Tags**: Fixed subscriber tags display by fetching tags via separate V4 API endpoint (#81, #75)
+- **Segment &amp; Sequence Counts**: Fixed misleading subscriber counts to show "N/A" instead of 0 when V4 API doesn't provide data (#82, #78, #79)
 
-**Bug Fixes:**
-- **Kit V4 API Compatibility**: Fixed authentication to use X-Kit-Api-Key header instead of Bearer token, corrected response parsing for V4 API format (#73)
-- **Test Infrastructure**: Fixed race conditions in parallel test execution for console output tests (#29, #28, #26)
-
-**Platform Updates:**
-- **Upgraded to .NET 10**: Migrated from .NET 9 to .NET 10 SDK with updated AOT compilation support (#53)
-- Updated test infrastructure dependencies: Microsoft.NET.Test.Sdk 17.14.1, coverlet.collector 6.0.4
-- Updated GitHub Actions workflows: setup-dotnet 5.0.1, download-artifact v7</PackageReleaseNotes>
+**Documentation:**
+- **Known Limitations**: Added documentation section explaining Kit V4 API constraints and workarounds (#86)</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Visual Studio C# settings -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,13 @@
+#### 1.1.1 January 6th 2026 ####
+
+**Bug Fixes:**
+- **Broadcast Analytics**: Fixed broadcast stats parsing and added per-URL click tracking support for Kit V4 API (#80, #77)
+- **Subscriber Tags**: Fixed subscriber tags display by fetching tags via separate V4 API endpoint (#81, #75)
+- **Segment & Sequence Counts**: Fixed misleading subscriber counts to show "N/A" instead of 0 when V4 API doesn't provide data (#82, #78, #79)
+
+**Documentation:**
+- **Known Limitations**: Added documentation section explaining Kit V4 API constraints and workarounds (#86)
+
 #### 1.1.0 January 5th 2026 ####
 
 **New Features:**


### PR DESCRIPTION
## Summary

Release preparation for version 1.1.1 - bug fixes for Kit V4 API compatibility.

### Changes

**Version Updates:**
- Updated `Directory.Build.props` to version 1.1.1
- Updated `RELEASE_NOTES.md` with release notes for 1.1.1

**Release Notes:**
- Fixed broadcast stats parsing and added per-URL click tracking support for Kit V4 API (#80, #77)
- Fixed subscriber tags display by fetching tags via separate V4 API endpoint (#81, #75)
- Fixed misleading subscriber counts to show "N/A" instead of 0 when V4 API doesn't provide data (#82, #78, #79)
- Added Known Limitations documentation section explaining Kit V4 API constraints and workarounds (#86)

### Files Changed
- `Directory.Build.props` - Version bump to 1.1.1 and updated package release notes
- `RELEASE_NOTES.md` - Added release notes for 1.1.1

## Next Steps

After this PR is merged:
1. Create and push git tag `1.1.1` from dev branch
2. GitHub Actions will automatically create the release

## Test plan
- [x] Build script executed successfully
- [x] Version metadata updated correctly
- [ ] CI passes