### PR TITLE
fix: Correct percentage display for Kit V4 API rates

### DIFF
--- a/src/KitCLI.Tests/Commands/BroadcastAnalyzeTests.cs
+++ b/src/KitCLI.Tests/Commands/BroadcastAnalyzeTests.cs
@@ -42,7 +42,7 @@ public class BroadcastAnalyzeTests : IDisposable
 
         var stats = new BroadcastStatsBuilder()
             .WithRecipients(2500)
-            .WithEngagement(0.42, 0.12) // 42% open, 12% click
+            .WithEngagement(42, 12) // 42% open, 12% click - Kit V4 API uses percentages (0-100)
             .Build();
 
         var mockClient = new MockKitApiClient
@@ -380,5 +380,54 @@ public class BroadcastAnalyzeTests : IDisposable
                 File.Delete(exportPath);
             }
         }
+    }
+
+    /// <summary>
+    /// Regression test for Issue #88: Broadcast stats shows impossible percentage values.
+    /// Kit V4 API returns rates as percentages (0-100), not decimals (0-1).
+    /// The bug was that code multiplied by 100, resulting in values like 3919% instead of 39.2%.
+    /// </summary>
+    [Fact]
+    public async Task HandleAnalyze_Should_Display_Correct_Percentages_From_Api()
+    {
+        // Arrange
+        // Simulate what the Kit V4 API actually returns: percentages in 0-100 format
+        var broadcast = new BroadcastBuilder()
+            .WithId(888)
+            .WithSubject("Percentage Bug Test")
+            .AsSent()
+            .Build();
+
+        var stats = new BroadcastStatsBuilder()
+            .WithRecipients(1000)
+            .WithOpenRate(39.19) // API returns 39.19 meaning 39.19%
+            .WithClickRate(8.5)   // API returns 8.5 meaning 8.5%
+            .WithEmailsOpened(420)
+            .WithTotalClicks(85)
+            .Build();
+
+        var mockClient = new MockKitApiClient
+        {
+            Broadcasts = new List<Broadcast> { broadcast },
+            BroadcastStats = new Dictionary<long, BroadcastStats> { [888] = stats }
+        };
+
+        var writer = new StringWriter();
+        Console.SetOut(writer);
+
+        // Act
+        var result = await BroadcastCommands.HandleAnalyze(["888"], mockClient);
+
+        // Assert
+        result.Should().Be(0);
+        var output = writer.ToString();
+
+        // Key assertion: Output should contain "39.2%" not "3919%"
+        output.Should().Contain("39.2%", "API returns 39.19 which means 39.19%, displayed as 39.2%");
+        output.Should().NotContain("3919", "Bug #88: rates should not be multiplied by 100 again");
+
+        // Also verify click rate is displayed correctly
+        output.Should().Contain("8.5%", "API returns 8.5 which means 8.5%");
+        output.Should().NotContain("850%", "Bug #88: click rate should not be multiplied by 100 again");
     }
 }

--- a/src/KitCLI.Tests/Helpers/OutputFormatterTests.cs
+++ b/src/KitCLI.Tests/Helpers/OutputFormatterTests.cs
@@ -158,13 +158,14 @@ public class OutputFormatterTests
         var originalOut = Console.Out;
         try
         {
+            // Kit V4 API returns rates as percentages (0-100), not decimals
             var stats = new BroadcastStats
             {
                 Recipients = 1000,
                 EmailsOpened = 400,
-                OpenRate = 0.4,
+                OpenRate = 40.0, // 40%
                 TotalClicks = 100,
-                ClickRate = 0.1,
+                ClickRate = 10.0, // 10%
                 Unsubscribes = 5,
                 Status = "completed"
             };

--- a/src/KitCLI.Tests/Mocks/MockKitApiClientTests.cs
+++ b/src/KitCLI.Tests/Mocks/MockKitApiClientTests.cs
@@ -82,7 +82,8 @@ public class MockKitApiClientTests
         // Assert
         result.Should().NotBeNull();
         result!.Recipients.Should().Be(2500);
-        result.OpenRate.Should().BeApproximately(0.45, 0.01);
+        // Kit V4 API returns rates as percentages (0-100), not decimals
+        result.OpenRate.Should().BeApproximately(45.0, 0.1);
     }
 
     [Fact]

--- a/src/KitCLI.Tests/TestData/Builders/BroadcastStatsBuilder.cs
+++ b/src/KitCLI.Tests/TestData/Builders/BroadcastStatsBuilder.cs
@@ -5,16 +5,18 @@ namespace KitCLI.Tests.TestData.Builders;
 /// <summary>
 /// Fluent builder for creating BroadcastStats test instances.
 /// Updated for Kit V4 API which provides different fields than the old API.
+/// IMPORTANT: Kit V4 API returns rates as percentages (0-100), not decimals (0-1).
 /// </summary>
 public sealed class BroadcastStatsBuilder
 {
     private int _recipients = 1000;
-    private double _openRate = 0.40; // 40%
-    private double _clickRate = 0.10; // 10%
+    // Kit V4 API returns rates as percentages (0-100), not decimals
+    private double _openRate = 40.0; // 40%
+    private double _clickRate = 10.0; // 10%
     private int _emailsOpened = 500;
     private int _totalClicks = 150;
     private int _unsubscribes = 5;
-    private double _unsubscribeRate = 0.005;
+    private double _unsubscribeRate = 0.5; // 0.5%
     private string? _status = "completed";
     private double _progress = 1.0;
     private bool _openTrackingDisabled = false;
@@ -95,11 +97,12 @@ public sealed class BroadcastStatsBuilder
 
     /// <summary>
     /// Create stats with high engagement (45% open, 15% click)
+    /// Kit V4 API returns rates as percentages (0-100)
     /// </summary>
     public BroadcastStatsBuilder WithHighEngagement()
     {
-        _openRate = 0.45;
-        _clickRate = 0.15;
+        _openRate = 45.0; // 45%
+        _clickRate = 15.0; // 15%
         _emailsOpened = (int)(_recipients * 0.45 * 1.3); // some re-opens
         _totalClicks = (int)(_recipients * 0.15 * 1.2);
         return this;
@@ -107,11 +110,12 @@ public sealed class BroadcastStatsBuilder
 
     /// <summary>
     /// Create stats with low engagement (15% open, 2% click)
+    /// Kit V4 API returns rates as percentages (0-100)
     /// </summary>
     public BroadcastStatsBuilder WithLowEngagement()
     {
-        _openRate = 0.15;
-        _clickRate = 0.02;
+        _openRate = 15.0; // 15%
+        _clickRate = 2.0; // 2%
         _emailsOpened = (int)(_recipients * 0.15 * 1.1);
         _totalClicks = (int)(_recipients * 0.02);
         return this;
@@ -119,25 +123,28 @@ public sealed class BroadcastStatsBuilder
 
     /// <summary>
     /// Create stats with typical engagement (35% open, 8% click)
+    /// Kit V4 API returns rates as percentages (0-100)
     /// </summary>
     public BroadcastStatsBuilder WithTypicalEngagement()
     {
-        _openRate = 0.35;
-        _clickRate = 0.08;
+        _openRate = 35.0; // 35%
+        _clickRate = 8.0; // 8%
         _emailsOpened = (int)(_recipients * 0.35 * 1.2);
         _totalClicks = (int)(_recipients * 0.08 * 1.1);
         return this;
     }
 
     /// <summary>
-    /// Set engagement by open and click percentages (0.0-1.0)
+    /// Set engagement by open and click percentages (0-100)
+    /// Kit V4 API returns rates as percentages, not decimals
     /// </summary>
-    public BroadcastStatsBuilder WithEngagement(double openRate, double clickRate)
+    public BroadcastStatsBuilder WithEngagement(double openRatePercent, double clickRatePercent)
     {
-        _openRate = openRate;
-        _clickRate = clickRate;
-        _emailsOpened = (int)(_recipients * openRate * 1.2);
-        _totalClicks = (int)(_recipients * clickRate * 1.1);
+        _openRate = openRatePercent;
+        _clickRate = clickRatePercent;
+        // Convert percentage to decimal for count calculations
+        _emailsOpened = (int)(_recipients * (openRatePercent / 100.0) * 1.2);
+        _totalClicks = (int)(_recipients * (clickRatePercent / 100.0) * 1.1);
         return this;
     }
 

--- a/src/KitCLI/Commands/BroadcastCommands.cs
+++ b/src/KitCLI/Commands/BroadcastCommands.cs
@@ -216,12 +216,12 @@ public static class BroadcastCommands
             return 1;
         }
 
-        // Kit V4 API provides emails_opened (total) and open_rate
-        // Estimate unique opens from rate
-        var estimatedUniqueOpens = (int)(stats.Recipients * stats.OpenRate);
-        progress.Complete($"Found {stats.EmailsOpened:N0} opens ({stats.OpenRate * 100:F1}%)");
+        // Kit V4 API provides emails_opened (total) and open_rate (as percentage 0-100)
+        // Estimate unique opens from rate (divide by 100 since API returns percentage)
+        var estimatedUniqueOpens = (int)(stats.Recipients * stats.OpenRate / 100.0);
+        progress.Complete($"Found {stats.EmailsOpened:N0} opens ({stats.OpenRate:F1}%)");
 
-        Console.WriteLine($"Broadcast opened {stats.EmailsOpened:N0} times ({stats.OpenRate * 100:F1}% open rate)");
+        Console.WriteLine($"Broadcast opened {stats.EmailsOpened:N0} times ({stats.OpenRate:F1}% open rate)");
         Console.WriteLine($"Estimated unique opens: ~{estimatedUniqueOpens:N0} subscribers");
         Console.WriteLine("Note: Kit API doesn't provide a list of subscribers who opened.");
 
@@ -298,7 +298,8 @@ public static class BroadcastCommands
             foreach (var click in clicks.OrderByDescending(c => c.UniqueClicks))
             {
                 var displayUrl = click.Url.Length > 45 ? click.Url[..42] + "..." : click.Url;
-                Console.WriteLine($"{click.UniqueClicks,-10:N0} {click.ClickToDeliveryRate * 100,-7:F2}% {displayUrl}");
+                // Kit V4 API returns rates as percentages (0-100)
+                Console.WriteLine($"{click.UniqueClicks,-10:N0} {click.ClickToDeliveryRate,-7:F2}% {displayUrl}");
             }
         }
 
@@ -358,14 +359,14 @@ public static class BroadcastCommands
             return 1;
         }
 
-        // Estimate unique opens from rate (Kit V4 API doesn't provide unique opens directly)
-        var estimatedUniqueOpens = (int)(stats.Recipients * stats.OpenRate);
+        // Estimate unique opens from rate (Kit V4 API returns percentage 0-100)
+        var estimatedUniqueOpens = (int)(stats.Recipients * stats.OpenRate / 100.0);
         var unopened = stats.Recipients - estimatedUniqueOpens;
-        var unopenedRate = 1.0 - stats.OpenRate;
+        var unopenedRate = 100.0 - stats.OpenRate;
 
-        progress.Complete($"Found ~{unopened:N0} subscribers who didn't open ({unopenedRate * 100:F1}%)");
+        progress.Complete($"Found ~{unopened:N0} subscribers who didn't open ({unopenedRate:F1}%)");
 
-        Console.WriteLine($"Estimated {unopened:N0} subscribers didn't open ({unopenedRate * 100:F1}%)");
+        Console.WriteLine($"Estimated {unopened:N0} subscribers didn't open ({unopenedRate:F1}%)");
         Console.WriteLine("Note: Kit API doesn't provide a list of subscribers who didn't open.");
 
         return 0;
@@ -442,22 +443,23 @@ public static class BroadcastCommands
 
         // Build analysis results
         var recipients = stats?.Recipients ?? 0;
-        // Estimate unique opens from rate (Kit V4 API doesn't provide unique opens directly)
-        var estimatedUniqueOpens = (int)(recipients * (stats?.OpenRate ?? 0));
+        // Estimate unique opens from rate (Kit V4 API returns percentage 0-100)
+        var estimatedUniqueOpens = (int)(recipients * (stats?.OpenRate ?? 0) / 100.0);
 
         // Get actual unique clicks by summing from the clicks endpoint
         var linkClicks = clicksResponse?.Broadcast?.Clicks ?? [];
         var uniqueClicks = linkClicks.Sum(c => c.UniqueClicks);
 
         // Map link clicks to analysis format
+        // Kit V4 API returns rates as percentages (0-100), normalize to decimals (0-1)
         var linkClickAnalysis = linkClicks
             .OrderByDescending(c => c.UniqueClicks)
             .Select(c => new LinkClickAnalysis
             {
                 Url = c.Url,
                 UniqueClicks = c.UniqueClicks,
-                ClickToDeliveryRate = c.ClickToDeliveryRate,
-                ClickToOpenRate = c.ClickToOpenRate
+                ClickToDeliveryRate = c.ClickToDeliveryRate / 100.0,
+                ClickToOpenRate = c.ClickToOpenRate / 100.0
             })
             .ToArray();
 
@@ -476,9 +478,10 @@ public static class BroadcastCommands
             UniqueClicks = uniqueClicks,
             TotalClicks = stats?.TotalClicks ?? 0,
             Unsubscribes = stats?.Unsubscribes ?? 0,
-            OpenRate = stats?.OpenRate ?? 0,
-            ClickRate = stats?.ClickRate ?? 0,
-            ClickToOpenRate = stats?.ClickToOpenRate ?? 0,
+            // Kit V4 API returns rates as percentages (0-100), normalize to decimals (0-1)
+            OpenRate = (stats?.OpenRate ?? 0) / 100.0,
+            ClickRate = (stats?.ClickRate ?? 0) / 100.0,
+            ClickToOpenRate = (stats?.ClickToOpenRate ?? 0) / 100.0,
             LinkClicks = linkClickAnalysis
         };
 

--- a/src/KitCLI/Helpers/OutputFormatter.cs
+++ b/src/KitCLI/Helpers/OutputFormatter.cs
@@ -156,8 +156,9 @@ public static class OutputFormatter
         Console.WriteLine($"Broadcast Statistics (ID: {broadcastId})");
         Console.WriteLine(new string('─', 50));
         Console.WriteLine($"Recipients:      {stats.Recipients:N0}");
-        Console.WriteLine($"Opens:           {stats.EmailsOpened:N0} ({stats.OpenRate * 100:F1}%)");
-        Console.WriteLine($"Clicks:          {stats.TotalClicks:N0} ({stats.ClickRate * 100:F1}%)");
+        // Kit V4 API returns rates as percentages (0-100), not decimals
+        Console.WriteLine($"Opens:           {stats.EmailsOpened:N0} ({stats.OpenRate:F1}%)");
+        Console.WriteLine($"Clicks:          {stats.TotalClicks:N0} ({stats.ClickRate:F1}%)");
         Console.WriteLine($"Unsubscribes:    {stats.Unsubscribes:N0}");
         if (!string.IsNullOrEmpty(stats.Status))
         {


### PR DESCRIPTION
## Summary

Fixes #88 - Broadcast stats showing impossible percentage values (e.g., 3919% instead of 39.2%)

**Root Cause**: Kit V4 API returns rates as percentages (0-100), not decimals (0-1). The code was incorrectly multiplying by 100, resulting in impossible values.

## Changes

- **OutputFormatter**: Display API rates directly without `*100` multiplication
- **BroadcastCommands**: Normalize rates by `/100` for internal calculations (progress bars, comparisons)
- **BroadcastStatsBuilder**: Updated test builder to use percentage values (0-100) to match actual API responses
- **Tests**: Added regression test `HandleAnalyze_Should_Display_Correct_Percentages_From_Api` to verify correct display

## Test plan

- [x] All existing tests pass (110 passed, 13 skipped)
- [x] New regression test verifies percentages display correctly
- [x] Test verifies "39.2%" is shown, not "3919%"