### PR TITLE
Release v1.1.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,14 +8,22 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>1.1.1</VersionPrefix>
-    <PackageReleaseNotes>**Bug Fixes:**
-- **Broadcast Analytics**: Fixed broadcast stats parsing and added per-URL click tracking support for Kit V4 API (#80, #77)
-- **Subscriber Tags**: Fixed subscriber tags display by fetching tags via separate V4 API endpoint (#81, #75)
-- **Segment &amp; Sequence Counts**: Fixed misleading subscriber counts to show "N/A" instead of 0 when V4 API doesn't provide data (#82, #78, #79)
+    <VersionPrefix>1.1.2</VersionPrefix>
+    <PackageReleaseNotes>**New Features:**
+- **Broadcast Click Analytics**: Added `kit broadcast clicks` command (with `clicks` alias) for detailed click data export (#91, #62)
+  - Multiple output formats: table, json, csv
+  - Export to file with --export flag (auto-detects format from extension)
+  - Shows per-link click metrics including unique clicks and rates
+  - AOT-compatible JSON serialization with new models
 
-**Documentation:**
-- **Known Limitations**: Added documentation section explaining Kit V4 API constraints and workarounds (#86)</PackageReleaseNotes>
+**Bug Fixes:**
+- **Broadcast Stats Display**: Fixed incorrect percentage calculations for Kit V4 API rates (#89, #88)
+  - Kit V4 API returns percentages (0-100), not decimals
+  - Corrected display to show actual rates instead of multiplied values (e.g., 39.2% instead of 3919%)
+  - Added regression test to prevent future issues
+
+**Testing Improvements:**
+- Added comprehensive unit tests for tag commands to verify functionality (#90, #76)</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Visual Studio C# settings -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,21 @@
+#### 1.1.2 January 6th 2026 ####
+
+**New Features:**
+- **Broadcast Click Analytics**: Added `kit broadcast clicks` command (with `clicks` alias) for detailed click data export (#91, #62)
+  - Multiple output formats: table, json, csv
+  - Export to file with --export flag (auto-detects format from extension)
+  - Shows per-link click metrics including unique clicks and rates
+  - AOT-compatible JSON serialization with new models
+
+**Bug Fixes:**
+- **Broadcast Stats Display**: Fixed incorrect percentage calculations for Kit V4 API rates (#89, #88)
+  - Kit V4 API returns percentages (0-100), not decimals
+  - Corrected display to show actual rates instead of multiplied values (e.g., 39.2% instead of 3919%)
+  - Added regression test to prevent future issues
+
+**Testing Improvements:**
+- Added comprehensive unit tests for tag commands to verify functionality (#90, #76)
+
 #### 1.1.1 January 6th 2026 ####
 
 **Bug Fixes:**


### PR DESCRIPTION
## Summary
Prepare release v1.1.2 with updated version metadata and release notes.

## Changes
- Updated Directory.Build.props with version 1.1.2
- Added release notes documenting:
  - New broadcast click analytics command
  - Bug fix for percentage display in broadcast stats
  - Testing improvements for tag commands

## Release Notes
**New Features:**
- **Broadcast Click Analytics**: Added `kit broadcast clicks` command (with `clicks` alias) for detailed click data export (#91, #62)
  - Multiple output formats: table, json, csv
  - Export to file with --export flag (auto-detects format from extension)
  - Shows per-link click metrics including unique clicks and rates
  - AOT-compatible JSON serialization with new models

**Bug Fixes:**
- **Broadcast Stats Display**: Fixed incorrect percentage calculations for Kit V4 API rates (#89, #88)
  - Kit V4 API returns percentages (0-100), not decimals
  - Corrected display to show actual rates instead of multiplied values (e.g., 39.2% instead of 3919%)
  - Added regression test to prevent future issues

**Testing Improvements:**
- Added comprehensive unit tests for tag commands to verify functionality (#90, #76)

## Next Steps
After merge, tag will be created and pushed to trigger release workflow.