### PR TITLE
feat: Add cohort by-tag command and fix segment display

### DIFF
--- a/src/KitCLI/Commands/CohortCommands.cs
+++ b/src/KitCLI/Commands/CohortCommands.cs
@@ -156,6 +156,356 @@ public static class CohortCommands
         return 0;
     }
 
+    /// <summary>
+    /// Handle the 'kit cohort by-tag' command.
+    /// Compares subscriber cohorts grouped by tags.
+    /// </summary>
+    public static async Task<int> HandleByTag(string[] args, IKitApiClient client)
+    {
+        // Parse arguments
+        string? tagsArg = null;
+        string? pattern = null;
+        string format = "table";
+        string? exportPath = null;
+
+        for (int i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--tags":
+                case "-t":
+                    if (i + 1 < args.Length)
+                    {
+                        tagsArg = args[++i];
+                    }
+                    break;
+                case "--pattern":
+                case "-p":
+                    if (i + 1 < args.Length)
+                    {
+                        pattern = args[++i];
+                    }
+                    break;
+                case "--format":
+                case "-f":
+                    if (i + 1 < args.Length)
+                    {
+                        format = args[++i].ToLowerInvariant();
+                    }
+                    break;
+                case "--export":
+                    if (i + 1 < args.Length)
+                    {
+                        exportPath = args[++i];
+                    }
+                    break;
+            }
+        }
+
+        // Validate arguments
+        if (string.IsNullOrEmpty(tagsArg) && string.IsNullOrEmpty(pattern))
+        {
+            Console.WriteLine("Usage: kit cohort by-tag --tags <tag1,tag2,...> [options]");
+            Console.WriteLine("       kit cohort by-tag --pattern <pattern> [options]");
+            Console.WriteLine();
+            Console.WriteLine("Options:");
+            Console.WriteLine("  --tags, -t <tags>       Comma-separated list of tag names or IDs");
+            Console.WriteLine("  --pattern, -p <pattern> Glob pattern to match tag names (e.g., 'training-*')");
+            Console.WriteLine("  --format, -f <format>   Output format: table (default), json, csv");
+            Console.WriteLine("  --export <path>         Export to file");
+            return 1;
+        }
+
+        using var progress = new ProgressIndicator("Loading tags");
+
+        // Get all tags
+        var allTags = await client.GetTagsAsync();
+        if (allTags.Length == 0)
+        {
+            progress.Complete("No tags found");
+            Console.WriteLine("No tags found in your account.");
+            return 1;
+        }
+
+        progress.Complete($"Found {allTags.Length} tags");
+
+        // Filter tags based on input
+        var selectedTags = new List<Tag>();
+
+        if (!string.IsNullOrEmpty(tagsArg))
+        {
+            var tagNames = tagsArg.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+            foreach (var tagName in tagNames)
+            {
+                // Try to find by ID first
+                if (long.TryParse(tagName, out var tagId))
+                {
+                    var tag = allTags.FirstOrDefault(t => t.Id == tagId);
+                    if (tag != null)
+                    {
+                        selectedTags.Add(tag);
+                        continue;
+                    }
+                }
+
+                // Find by name (case-insensitive)
+                var matchingTag = allTags.FirstOrDefault(t =>
+                    t.Name.Equals(tagName, StringComparison.OrdinalIgnoreCase));
+
+                if (matchingTag != null)
+                {
+                    selectedTags.Add(matchingTag);
+                }
+                else
+                {
+                    Console.WriteLine($"Warning: Tag '{tagName}' not found, skipping.");
+                }
+            }
+        }
+
+        if (!string.IsNullOrEmpty(pattern))
+        {
+            // Simple glob pattern matching (supports * wildcard)
+            var regexPattern = "^" + System.Text.RegularExpressions.Regex.Escape(pattern)
+                .Replace("\\*", ".*") + "$";
+
+            var regex = new System.Text.RegularExpressions.Regex(regexPattern,
+                System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+
+            foreach (var tag in allTags)
+            {
+                if (regex.IsMatch(tag.Name) && !selectedTags.Any(t => t.Id == tag.Id))
+                {
+                    selectedTags.Add(tag);
+                }
+            }
+        }
+
+        if (selectedTags.Count == 0)
+        {
+            Console.WriteLine("No matching tags found.");
+            return 1;
+        }
+
+        if (selectedTags.Count == 1)
+        {
+            Console.WriteLine("At least 2 tags are required for comparison.");
+            return 1;
+        }
+
+        Console.WriteLine($"\nComparing {selectedTags.Count} tags: {string.Join(", ", selectedTags.Select(t => t.Name))}");
+
+        // Fetch subscribers for each tag
+        var tagCohorts = new List<TagCohort>();
+
+        foreach (var tag in selectedTags)
+        {
+            using var tagProgress = new ProgressIndicator($"Fetching subscribers for '{tag.Name}'");
+
+            var subscribers = new List<Subscriber>();
+            string? cursor = null;
+            bool hasMore = true;
+
+            while (hasMore)
+            {
+                var response = await client.GetTagSubscribersAsync(tag.Id, 100, cursor);
+
+                foreach (var sub in response.Data)
+                {
+                    subscribers.Add(sub);
+                }
+
+                if (response.Pagination != null && response.Pagination.HasNextPage)
+                {
+                    cursor = response.Pagination.EndCursor;
+                }
+                else
+                {
+                    hasMore = false;
+                }
+            }
+
+            tagProgress.Complete($"Found {subscribers.Count:N0} subscribers");
+
+            // Calculate metrics
+            var active = subscribers.Count(s => s.State.Equals("active", StringComparison.OrdinalIgnoreCase));
+            var cancelled = subscribers.Count(s => s.State.Equals("cancelled", StringComparison.OrdinalIgnoreCase));
+
+            tagCohorts.Add(new TagCohort
+            {
+                TagId = tag.Id,
+                TagName = tag.Name,
+                TotalSubscribers = subscribers.Count,
+                ActiveSubscribers = active,
+                CancelledSubscribers = cancelled,
+                RetentionRate = subscribers.Count > 0 ? (double)active / subscribers.Count * 100 : 0
+            });
+        }
+
+        // Sort by subscriber count descending
+        var sortedCohorts = tagCohorts.OrderByDescending(c => c.TotalSubscribers).ToArray();
+
+        // Generate insights
+        var insight = GenerateTagInsight(sortedCohorts);
+
+        var result = new TagCohortAnalysisResult
+        {
+            AnalysisType = "by-tag",
+            TagCount = sortedCohorts.Length,
+            TotalSubscribersAnalyzed = sortedCohorts.Sum(c => c.TotalSubscribers),
+            Cohorts = sortedCohorts,
+            Insight = insight
+        };
+
+        // Output results
+        if (exportPath != null)
+        {
+            return await ExportTagCohortAnalysis(result, exportPath);
+        }
+
+        PrintTagCohortAnalysis(result, format);
+        return 0;
+    }
+
+    private static string GenerateTagInsight(TagCohort[] cohorts)
+    {
+        if (cohorts.Length < 2)
+        {
+            return "Not enough cohorts for comparison.";
+        }
+
+        var insights = new List<string>();
+
+        // Find highest and lowest retention
+        var highestRetention = cohorts.MaxBy(c => c.RetentionRate);
+        var lowestRetention = cohorts.MinBy(c => c.RetentionRate);
+
+        if (highestRetention != null && lowestRetention != null && highestRetention.TagId != lowestRetention.TagId)
+        {
+            var diff = highestRetention.RetentionRate - lowestRetention.RetentionRate;
+            if (diff > 5)
+            {
+                insights.Add($"'{highestRetention.TagName}' has {diff:F1}% higher retention than '{lowestRetention.TagName}'.");
+            }
+        }
+
+        // Find largest cohort
+        var largest = cohorts.MaxBy(c => c.TotalSubscribers);
+        if (largest != null)
+        {
+            insights.Add($"Largest cohort: '{largest.TagName}' with {largest.TotalSubscribers:N0} subscribers.");
+        }
+
+        // Check for small sample sizes
+        var smallCohorts = cohorts.Where(c => c.TotalSubscribers < 30).ToList();
+        if (smallCohorts.Count > 0)
+        {
+            insights.Add($"Note: {smallCohorts.Count} tag(s) have fewer than 30 subscribers (low statistical significance).");
+        }
+
+        return insights.Count > 0 ? string.Join(" ", insights) : "Tag cohorts are similar in retention rates.";
+    }
+
+    private static void PrintTagCohortAnalysis(TagCohortAnalysisResult result, string format)
+    {
+        switch (format.ToLowerInvariant())
+        {
+            case "json":
+                PrintTagCohortJson(result);
+                break;
+            case "csv":
+                PrintTagCohortCsv(result);
+                break;
+            default:
+                PrintTagCohortTable(result);
+                break;
+        }
+    }
+
+    private static void PrintTagCohortTable(TagCohortAnalysisResult result)
+    {
+        Console.WriteLine();
+        Console.WriteLine("Tag Cohort Comparison");
+        Console.WriteLine(new string('─', 90));
+
+        Console.WriteLine($"{"Tag",-30} {"Subscribers",12} {"Active",10} {"Cancelled",10} {"Retention",12}");
+        Console.WriteLine(new string('─', 90));
+
+        foreach (var cohort in result.Cohorts)
+        {
+            var tagName = cohort.TagName.Length > 28 ? cohort.TagName[..28] + ".." : cohort.TagName;
+            Console.WriteLine($"{tagName,-30} {cohort.TotalSubscribers,12:N0} {cohort.ActiveSubscribers,10:N0} {cohort.CancelledSubscribers,10:N0} {cohort.RetentionRate,11:F1}%");
+        }
+
+        Console.WriteLine(new string('─', 90));
+        Console.WriteLine($"{"Total",-30} {result.TotalSubscribersAnalyzed,12:N0}");
+        Console.WriteLine();
+        Console.WriteLine($"Insight: {result.Insight}");
+    }
+
+    private static void PrintTagCohortJson(TagCohortAnalysisResult result)
+    {
+        var json = JsonSerializer.Serialize(result, KitJsonIndentedContext.Default.TagCohortAnalysisResult);
+        Console.WriteLine(json);
+    }
+
+    private static void PrintTagCohortCsv(TagCohortAnalysisResult result)
+    {
+        Console.WriteLine("tag_id,tag_name,total_subscribers,active_subscribers,cancelled_subscribers,retention_rate");
+
+        foreach (var cohort in result.Cohorts)
+        {
+            var tagName = EscapeCsvField(cohort.TagName);
+            Console.WriteLine($"{cohort.TagId},{tagName},{cohort.TotalSubscribers},{cohort.ActiveSubscribers},{cohort.CancelledSubscribers},{cohort.RetentionRate:F2}");
+        }
+    }
+
+    private static async Task<int> ExportTagCohortAnalysis(TagCohortAnalysisResult result, string outputPath)
+    {
+        var fileFormat = Path.GetExtension(outputPath).ToLowerInvariant() switch
+        {
+            ".json" => "json",
+            ".csv" => "csv",
+            _ => "csv"
+        };
+
+        if (!outputPath.Contains('.'))
+        {
+            outputPath += ".csv";
+        }
+
+        await using var writer = new StreamWriter(outputPath);
+
+        if (fileFormat == "json")
+        {
+            var json = JsonSerializer.Serialize(result, KitJsonIndentedContext.Default.TagCohortAnalysisResult);
+            await writer.WriteAsync(json);
+        }
+        else
+        {
+            await writer.WriteLineAsync("tag_id,tag_name,total_subscribers,active_subscribers,cancelled_subscribers,retention_rate");
+
+            foreach (var cohort in result.Cohorts)
+            {
+                var tagName = EscapeCsvField(cohort.TagName);
+                await writer.WriteLineAsync($"{cohort.TagId},{tagName},{cohort.TotalSubscribers},{cohort.ActiveSubscribers},{cohort.CancelledSubscribers},{cohort.RetentionRate:F2}");
+            }
+        }
+
+        Console.WriteLine($"Exported tag cohort analysis to {outputPath}");
+        return 0;
+    }
+
+    private static string EscapeCsvField(string field)
+    {
+        if (field.Contains(',') || field.Contains('"') || field.Contains('\n'))
+        {
+            return "\"" + field.Replace("\"", "\"\"") + "\"";
+        }
+        return field;
+    }
+
     private static List<SignupCohort> GroupIntoCohorts(List<Subscriber> subscribers, string period)
     {
         var grouped = period switch

--- a/src/KitCLI/Commands/SegmentCommands.cs
+++ b/src/KitCLI/Commands/SegmentCommands.cs
@@ -242,7 +242,7 @@ public static class SegmentCommands
         Console.WriteLine(new string('═', 60));
         Console.WriteLine($"Name: {segment.Name}");
         Console.WriteLine($"Description: {segment.Description ?? "(none)"}");
-        Console.WriteLine("Subscribers: N/A (use 'kit segment subscribers <id> --all' to count)");
+        Console.WriteLine($"Subscribers: {segment.SubscriberCount:N0}");
         Console.WriteLine($"Created: {segment.CreatedAt:yyyy-MM-dd}");
         Console.WriteLine($"Last Updated: {segment.UpdatedAt?.ToString("yyyy-MM-dd") ?? "Never"}");
         Console.WriteLine($"Processing: {(segment.IsProcessing ? "Yes" : "No")}");
@@ -321,19 +321,13 @@ public static class SegmentCommands
         Console.WriteLine($"\n{"Metric",-25} │ {TruncateString(segment1.Name, 25),-25} │ {TruncateString(segment2.Name, 25),-25}");
         Console.WriteLine(new string('─', 80));
 
-        // Note: Kit V4 API doesn't return subscriber_count for segments
-        Console.WriteLine($"{"Subscribers",-25} │ {"N/A",25} │ {"N/A",25}");
+        Console.WriteLine($"{"Subscribers",-25} │ {segment1.SubscriberCount,25:N0} │ {segment2.SubscriberCount,25:N0}");
         Console.WriteLine($"{"Created",-25} │ {segment1.CreatedAt,25:yyyy-MM-dd} │ {segment2.CreatedAt,25:yyyy-MM-dd}");
         Console.WriteLine($"{"Last Updated",-25} │ {segment1.UpdatedAt?.ToString("yyyy-MM-dd") ?? "Never",25} │ {segment2.UpdatedAt?.ToString("yyyy-MM-dd") ?? "Never",25}");
         Console.WriteLine($"{"Filter Count",-25} │ {segment1.Filters?.Length ?? 0,25} │ {segment2.Filters?.Length ?? 0,25}");
         Console.WriteLine($"{"Is Processing",-25} │ {(segment1.IsProcessing ? "Yes" : "No"),25} │ {(segment2.IsProcessing ? "Yes" : "No"),25}");
 
         Console.WriteLine(new string('─', 80));
-
-        Console.WriteLine("\n📊 Notes:");
-        Console.WriteLine("• Subscriber counts are not available from Kit V4 API");
-        Console.WriteLine("• Use 'kit segment subscribers <id> --all' to count subscribers for each segment");
-        Console.WriteLine("• Subscriber overlap analysis requires additional API implementation");
 
         return 0;
     }
@@ -411,9 +405,8 @@ public static class SegmentCommands
                 var name = EscapeCsvField(segment.Name);
                 var description = EscapeCsvField(segment.Description ?? "");
 
-                // Note: Kit V4 API doesn't return subscriber_count for segments
                 await writer.WriteLineAsync(
-                    $"{segment.Id},{name},{description},," +
+                    $"{segment.Id},{name},{description},{segment.SubscriberCount}," +
                     $"{segment.CreatedAt:yyyy-MM-dd'T'HH:mm:ss'Z'}," +
                     $"{segment.UpdatedAt?.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'") ?? ""}");
             }
@@ -458,9 +451,9 @@ public static class SegmentCommands
             var name = TruncateString(segment.Name, nameWidth);
             var desc = TruncateString(segment.Description ?? "", descWidth);
             var created = segment.CreatedAt.ToString("yyyy-MM-dd");
+            var count = segment.SubscriberCount > 0 ? segment.SubscriberCount.ToString("N0") : "0";
 
-            // Note: Kit V4 API doesn't return subscriber_count for segments
-            Console.WriteLine($"│ {segment.Id,-idWidth} │ {name,-nameWidth} │ {desc,-descWidth} │ {"N/A",countWidth} │ {created,-createdWidth} │");
+            Console.WriteLine($"│ {segment.Id,-idWidth} │ {name,-nameWidth} │ {desc,-descWidth} │ {count,countWidth} │ {created,-createdWidth} │");
         }
 
         Console.WriteLine(new string('─', idWidth + nameWidth + descWidth + countWidth + createdWidth + 10));

--- a/src/KitCLI/Helpers/CommandHelp.cs
+++ b/src/KitCLI/Helpers/CommandHelp.cs
@@ -492,7 +492,8 @@ public static class CommandHelp
             Description = "Analyze subscriber cohorts over time to understand engagement patterns",
             Subcommands = new Dictionary<string, string>
             {
-                ["by-signup"] = "Analyze engagement by signup date cohort"
+                ["by-signup"] = "Analyze engagement by signup date cohort",
+                ["by-tag"] = "Compare subscriber cohorts by tag"
             }
         },
         ["cohort by-signup"] = new CommandHelpInfo
@@ -513,6 +514,25 @@ public static class CommandHelp
                 "kit cohort by-signup --period quarterly",
                 "kit cohort by-signup --days 730 --export cohorts.csv",
                 "kit cohort by-signup --period weekly --format json"
+            }
+        },
+        ["cohort by-tag"] = new CommandHelpInfo
+        {
+            Usage = "kit cohort by-tag [options]",
+            Description = "Compare subscriber cohorts by tag. Analyzes retention and engagement metrics for subscribers with specific tags.",
+            Options = new Dictionary<string, string>
+            {
+                ["--tags, -t <tags>"] = "Comma-separated list of tag names or IDs to compare",
+                ["--pattern, -p <pattern>"] = "Glob pattern to match tag names (e.g., 'training-*')",
+                ["--format, -f <format>"] = "Output format: table (default), json, csv",
+                ["--export <path>"] = "Export to file (CSV or JSON based on extension)"
+            },
+            Examples = new[]
+            {
+                "kit cohort by-tag --tags newsletter,webinar,course",
+                "kit cohort by-tag --pattern 'lead-*'",
+                "kit cohort by-tag --tags 12345,67890 --format json",
+                "kit cohort by-tag --pattern 'course-*' --export tag-cohorts.csv"
             }
         }
     };

--- a/src/KitCLI/KitJsonContext.cs
+++ b/src/KitCLI/KitJsonContext.cs
@@ -95,6 +95,9 @@ namespace KitCLI;
 [JsonSerializable(typeof(CohortAgeMetric))]
 [JsonSerializable(typeof(CohortAgeMetric[]))]
 [JsonSerializable(typeof(CohortAnalysisResult))]
+[JsonSerializable(typeof(TagCohort))]
+[JsonSerializable(typeof(TagCohort[]))]
+[JsonSerializable(typeof(TagCohortAnalysisResult))]
 public partial class KitJsonContext : JsonSerializerContext
 {
 }
@@ -137,6 +140,9 @@ public partial class KitJsonContext : JsonSerializerContext
 [JsonSerializable(typeof(CohortAgeMetric))]
 [JsonSerializable(typeof(CohortAgeMetric[]))]
 [JsonSerializable(typeof(CohortAnalysisResult))]
+[JsonSerializable(typeof(TagCohort))]
+[JsonSerializable(typeof(TagCohort[]))]
+[JsonSerializable(typeof(TagCohortAnalysisResult))]
 public partial class KitJsonIndentedContext : JsonSerializerContext
 {
 }

--- a/src/KitCLI/Models/CohortAnalysis.cs
+++ b/src/KitCLI/Models/CohortAnalysis.cs
@@ -157,3 +157,81 @@ public sealed class CohortAnalysisResult
     [JsonPropertyName("half_life_days")]
     public int? HalfLifeDays { get; set; }
 }
+
+/// <summary>
+/// Represents a cohort of subscribers grouped by tag.
+/// </summary>
+public sealed class TagCohort
+{
+    /// <summary>
+    /// The tag ID
+    /// </summary>
+    [JsonPropertyName("tag_id")]
+    public long TagId { get; set; }
+
+    /// <summary>
+    /// The tag name
+    /// </summary>
+    [JsonPropertyName("tag_name")]
+    public string TagName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Total subscribers with this tag
+    /// </summary>
+    [JsonPropertyName("total_subscribers")]
+    public int TotalSubscribers { get; set; }
+
+    /// <summary>
+    /// Currently active subscribers with this tag
+    /// </summary>
+    [JsonPropertyName("active_subscribers")]
+    public int ActiveSubscribers { get; set; }
+
+    /// <summary>
+    /// Subscribers who have cancelled with this tag
+    /// </summary>
+    [JsonPropertyName("cancelled_subscribers")]
+    public int CancelledSubscribers { get; set; }
+
+    /// <summary>
+    /// Retention rate (active / total) as percentage 0-100
+    /// </summary>
+    [JsonPropertyName("retention_rate")]
+    public double RetentionRate { get; set; }
+}
+
+/// <summary>
+/// Complete result of a tag-based cohort analysis.
+/// </summary>
+public sealed class TagCohortAnalysisResult
+{
+    /// <summary>
+    /// Type of analysis performed
+    /// </summary>
+    [JsonPropertyName("analysis_type")]
+    public string AnalysisType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Number of tags analyzed
+    /// </summary>
+    [JsonPropertyName("tag_count")]
+    public int TagCount { get; set; }
+
+    /// <summary>
+    /// Total subscribers analyzed across all tags
+    /// </summary>
+    [JsonPropertyName("total_subscribers_analyzed")]
+    public int TotalSubscribersAnalyzed { get; set; }
+
+    /// <summary>
+    /// The tag cohorts with their analysis data
+    /// </summary>
+    [JsonPropertyName("cohorts")]
+    public TagCohort[] Cohorts { get; set; } = [];
+
+    /// <summary>
+    /// Auto-generated insight about the data
+    /// </summary>
+    [JsonPropertyName("insight")]
+    public string Insight { get; set; } = string.Empty;
+}

--- a/src/KitCLI/Program.cs
+++ b/src/KitCLI/Program.cs
@@ -842,6 +842,7 @@ static async Task<int> HandleCohortCommand(string[] args, bool isReadOnly)
     return args[0].ToLowerInvariant() switch
     {
         "by-signup" => await CohortCommands.HandleBySignup(args[1..], client),
+        "by-tag" => await CohortCommands.HandleByTag(args[1..], client),
         _ => ShowUnknownCommand($"cohort {args[0]}")
     };
 }


### PR DESCRIPTION
## Summary

- Add `kit cohort by-tag` command to compare subscriber cohorts by tag (#67)
- Fix segment subscriber counts showing actual values instead of N/A (#93)

## Changes

### Cohort by-tag command
- Compare subscriber retention across multiple tags
- Select tags by name, ID, or glob pattern (`--pattern 'training-*'`)
- Calculate retention rate (active/total) for each tag cohort
- Generate insights comparing retention across tags
- Support table, JSON, and CSV output formats
- Export to file support

### Segment subscriber count fix
- Display actual subscriber count from API instead of hardcoded "N/A"
- Shows "0" when segment has no subscribers
- Applied to list, analyze, compare, and export commands

## Test plan
- [x] Build succeeds
- [x] All tests pass (115 passed, 13 skipped)
- [x] `kit cohort --help` shows both subcommands
- [x] `kit cohort by-tag --help` shows correct usage

Closes #67, closes #93