### PR TITLE
feat: Add kit cohort by-form command for lead source analysis

### DIFF
--- a/src/KitCLI.Tests/Mocks/MockKitApiClient.cs
+++ b/src/KitCLI.Tests/Mocks/MockKitApiClient.cs
@@ -42,7 +42,7 @@ public sealed class MockKitApiClient : IKitApiClient
     public Func<long, CancellationToken, Task<SequenceStats?>>? GetSequenceStatsAsyncFunc { get; set; }
 
     // Forms
-    public Func<int, string?, CancellationToken, Task<PaginatedResponse<Form>>>? GetFormsAsyncFunc { get; set; }
+    public Func<int, string?, CancellationToken, Task<FormsResponse>>? GetFormsAsyncFunc { get; set; }
     public Func<int, CancellationToken, IAsyncEnumerable<Form>>? GetAllFormsAsyncFunc { get; set; }
     public Func<long, CancellationToken, Task<Form?>>? GetFormAsyncFunc { get; set; }
     public Func<long, int, string?, CancellationToken, Task<PaginatedResponse<Subscriber>>>? GetFormSubscribersAsyncFunc { get; set; }
@@ -342,7 +342,7 @@ public sealed class MockKitApiClient : IKitApiClient
     }
 
     // Forms
-    public Task<PaginatedResponse<Form>> GetFormsAsync(
+    public Task<FormsResponse> GetFormsAsync(
         int perPage = 50, string? after = null, CancellationToken cancellationToken = default)
     {
         if (GetFormsAsyncFunc != null)
@@ -350,9 +350,9 @@ public sealed class MockKitApiClient : IKitApiClient
             return GetFormsAsyncFunc(perPage, after, cancellationToken);
         }
 
-        return Task.FromResult(new PaginatedResponse<Form>
+        return Task.FromResult(new FormsResponse
         {
-            Data = Forms.Take(perPage).ToArray(),
+            Forms = Forms.Take(perPage).ToArray(),
             Pagination = new PaginationInfo { HasNextPage = false }
         });
     }

--- a/src/KitCLI/Commands/CohortCommands.cs
+++ b/src/KitCLI/Commands/CohortCommands.cs
@@ -855,4 +855,458 @@ public static class CohortCommands
         Console.WriteLine($"Exported cohort analysis to {outputPath}");
         return 0;
     }
+
+    /// <summary>
+    /// Handle the 'kit cohort by-form' command.
+    /// Analyzes subscriber cohorts by their signup form.
+    /// </summary>
+    public static async Task<int> HandleByForm(string[] args, IKitApiClient client)
+    {
+        // Parse arguments
+        string? formIdsArg = null;
+        int lookbackDays = 365;
+        string format = "table";
+        string? exportPath = null;
+        bool compare = false;
+        bool includeArchived = false;
+
+        for (int i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--form-ids":
+                case "-f":
+                    if (i + 1 < args.Length)
+                    {
+                        formIdsArg = args[++i];
+                    }
+                    break;
+                case "--days":
+                case "-d":
+                    if (i + 1 < args.Length && int.TryParse(args[++i], out var days))
+                    {
+                        lookbackDays = days;
+                    }
+                    break;
+                case "--format":
+                    if (i + 1 < args.Length)
+                    {
+                        format = args[++i].ToLowerInvariant();
+                    }
+                    break;
+                case "--export":
+                    if (i + 1 < args.Length)
+                    {
+                        exportPath = args[++i];
+                    }
+                    break;
+                case "--compare":
+                    compare = true;
+                    break;
+                case "--include-archived":
+                    includeArchived = true;
+                    break;
+            }
+        }
+
+        using var progress = new ProgressIndicator("Loading forms");
+
+        // Get all forms
+        var formsResponse = await client.GetFormsAsync(100);
+        var allForms = formsResponse.Forms.ToList();
+
+        // Fetch remaining pages if any
+        while (formsResponse.Pagination?.HasNextPage == true)
+        {
+            formsResponse = await client.GetFormsAsync(100, formsResponse.Pagination.EndCursor);
+            allForms.AddRange(formsResponse.Forms);
+        }
+
+        if (allForms.Count == 0)
+        {
+            progress.Complete("No forms found");
+            Console.WriteLine("No forms found in your account.");
+            return 1;
+        }
+
+        // Filter archived if not including them
+        if (!includeArchived)
+        {
+            allForms = allForms.Where(f => !f.Archived).ToList();
+        }
+
+        progress.Complete($"Found {allForms.Count} forms");
+
+        // Filter to specific forms if requested
+        var selectedForms = new List<Form>();
+
+        if (!string.IsNullOrEmpty(formIdsArg))
+        {
+            var formIds = formIdsArg.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+            foreach (var formIdStr in formIds)
+            {
+                if (long.TryParse(formIdStr, out var formId))
+                {
+                    var form = allForms.FirstOrDefault(f => f.Id == formId);
+                    if (form != null)
+                    {
+                        selectedForms.Add(form);
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Warning: Form ID '{formId}' not found, skipping.");
+                    }
+                }
+                else
+                {
+                    // Try to find by name
+                    var form = allForms.FirstOrDefault(f =>
+                        f.Name.Equals(formIdStr, StringComparison.OrdinalIgnoreCase));
+                    if (form != null)
+                    {
+                        selectedForms.Add(form);
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Warning: Form '{formIdStr}' not found, skipping.");
+                    }
+                }
+            }
+
+            if (selectedForms.Count == 0)
+            {
+                Console.WriteLine("No matching forms found.");
+                return 1;
+            }
+        }
+        else
+        {
+            selectedForms = allForms;
+        }
+
+        if (compare && selectedForms.Count < 2)
+        {
+            Console.WriteLine("At least 2 forms are required for comparison. Use --form-ids to specify forms.");
+            return 1;
+        }
+
+        Console.WriteLine($"\nAnalyzing {selectedForms.Count} form(s) (last {lookbackDays} days)");
+
+        var cutoffDate = DateTime.UtcNow.AddDays(-lookbackDays);
+        var cutoff90d = DateTime.UtcNow.AddDays(-90);
+        var cutoff30d = DateTime.UtcNow.AddDays(-30);
+
+        // Fetch subscribers for each form
+        var formCohorts = new List<FormCohort>();
+
+        foreach (var form in selectedForms)
+        {
+            using var formProgress = new ProgressIndicator($"Analyzing '{form.Name}'");
+
+            var subscribers = new List<Subscriber>();
+
+            await foreach (var subscriber in client.GetAllFormSubscribersAsync(form.Id, 1000))
+            {
+                // Only include subscribers from the lookback period
+                if (subscriber.CreatedAt >= cutoffDate)
+                {
+                    subscribers.Add(subscriber);
+                }
+            }
+
+            formProgress.Complete($"Found {subscribers.Count:N0} subscribers");
+
+            if (subscribers.Count == 0)
+            {
+                formCohorts.Add(new FormCohort
+                {
+                    FormId = form.Id,
+                    FormName = form.Name,
+                    FormType = form.Type,
+                    TotalSubscribers = 0,
+                    ActiveSubscribers = 0,
+                    CancelledSubscribers = 0,
+                    BouncedSubscribers = 0,
+                    ComplainedSubscribers = 0,
+                    RetentionRate = 0,
+                    RecentSignups30d = 0,
+                    RecentSignups90d = 0,
+                    Retention90d = null,
+                    Archived = form.Archived,
+                    CreatedAt = form.CreatedAt
+                });
+                continue;
+            }
+
+            // Calculate metrics
+            var active = subscribers.Count(s => s.State.Equals("active", StringComparison.OrdinalIgnoreCase));
+            var cancelled = subscribers.Count(s => s.State.Equals("cancelled", StringComparison.OrdinalIgnoreCase));
+            var bounced = subscribers.Count(s => s.State.Equals("bounced", StringComparison.OrdinalIgnoreCase));
+            var complained = subscribers.Count(s => s.State.Equals("complained", StringComparison.OrdinalIgnoreCase));
+
+            var recentSignups30d = subscribers.Count(s => s.CreatedAt >= cutoff30d);
+            var recentSignups90d = subscribers.Count(s => s.CreatedAt >= cutoff90d);
+
+            // 90-day retention: of subscribers who signed up 90+ days ago, how many are still active?
+            var older90d = subscribers.Where(s => s.CreatedAt < cutoff90d).ToList();
+            double? retention90d = null;
+            if (older90d.Count >= 10) // Need at least 10 for meaningful stat
+            {
+                var activeOlder = older90d.Count(s => s.State.Equals("active", StringComparison.OrdinalIgnoreCase));
+                retention90d = (double)activeOlder / older90d.Count * 100;
+            }
+
+            formCohorts.Add(new FormCohort
+            {
+                FormId = form.Id,
+                FormName = form.Name,
+                FormType = form.Type,
+                TotalSubscribers = subscribers.Count,
+                ActiveSubscribers = active,
+                CancelledSubscribers = cancelled,
+                BouncedSubscribers = bounced,
+                ComplainedSubscribers = complained,
+                RetentionRate = subscribers.Count > 0 ? (double)active / subscribers.Count * 100 : 0,
+                RecentSignups30d = recentSignups30d,
+                RecentSignups90d = recentSignups90d,
+                Retention90d = retention90d,
+                Archived = form.Archived,
+                CreatedAt = form.CreatedAt
+            });
+        }
+
+        // Sort by subscriber count descending
+        var sortedCohorts = formCohorts.OrderByDescending(c => c.TotalSubscribers).ToArray();
+
+        // Calculate aggregate metrics
+        var totalSubs = sortedCohorts.Sum(c => c.TotalSubscribers);
+        var cohortsWithSubs = sortedCohorts.Where(c => c.TotalSubscribers > 0).ToList();
+        var avgRetention = cohortsWithSubs.Count > 0 ? cohortsWithSubs.Average(c => c.RetentionRate) : 0;
+
+        // Find best and worst performers (with minimum subscriber threshold)
+        var significantCohorts = sortedCohorts.Where(c => c.TotalSubscribers >= 10).ToList();
+        var bestForm = significantCohorts.MaxBy(c => c.RetentionRate);
+        var worstForm = significantCohorts.MinBy(c => c.RetentionRate);
+
+        // Generate insights
+        var insight = GenerateFormInsight(sortedCohorts, bestForm, worstForm, avgRetention);
+
+        var result = new FormCohortAnalysisResult
+        {
+            AnalysisType = "by-form",
+            FormCount = sortedCohorts.Length,
+            TotalSubscribersAnalyzed = totalSubs,
+            LookbackDays = lookbackDays,
+            Cohorts = sortedCohorts,
+            Insight = insight,
+            AverageRetentionRate = avgRetention,
+            BestForm = bestForm?.FormName,
+            WorstForm = worstForm?.FormName
+        };
+
+        // Output results
+        if (exportPath != null)
+        {
+            return await ExportFormCohortAnalysis(result, exportPath);
+        }
+
+        if (compare && selectedForms.Count >= 2)
+        {
+            PrintFormComparisonTable(result);
+        }
+        else
+        {
+            PrintFormCohortAnalysis(result, format);
+        }
+
+        return 0;
+    }
+
+    private static string GenerateFormInsight(FormCohort[] cohorts, FormCohort? bestForm, FormCohort? worstForm, double avgRetention)
+    {
+        if (cohorts.Length == 0)
+        {
+            return "No form data available.";
+        }
+
+        var insights = new List<string>();
+
+        // Best vs worst comparison
+        if (bestForm != null && worstForm != null && bestForm.FormId != worstForm.FormId)
+        {
+            var diff = bestForm.RetentionRate - worstForm.RetentionRate;
+            if (diff > 10)
+            {
+                var multiplier = bestForm.RetentionRate / Math.Max(worstForm.RetentionRate, 1);
+                insights.Add($"'{bestForm.FormName}' has {diff:F0}% higher retention than '{worstForm.FormName}' ({multiplier:F1}x better).");
+            }
+        }
+
+        // Find high-volume forms with good retention
+        var highVolume = cohorts.Where(c => c.TotalSubscribers >= 100 && c.RetentionRate > avgRetention).ToList();
+        if (highVolume.Count > 0)
+        {
+            var best = highVolume.MaxBy(c => c.TotalSubscribers);
+            if (best != null)
+            {
+                insights.Add($"Best high-volume performer: '{best.FormName}' ({best.TotalSubscribers:N0} subs, {best.RetentionRate:F1}% retention).");
+            }
+        }
+
+        // Check for forms with poor 90-day retention
+        var poor90d = cohorts.Where(c => c.Retention90d.HasValue && c.Retention90d < 50 && c.TotalSubscribers >= 30).ToList();
+        if (poor90d.Count > 0)
+        {
+            insights.Add($"{poor90d.Count} form(s) have below 50% 90-day retention - consider reviewing lead quality.");
+        }
+
+        // Check for small sample sizes
+        var smallCohorts = cohorts.Where(c => c.TotalSubscribers > 0 && c.TotalSubscribers < 30).ToList();
+        if (smallCohorts.Count > 0)
+        {
+            insights.Add($"Note: {smallCohorts.Count} form(s) have fewer than 30 subscribers (limited statistical significance).");
+        }
+
+        return insights.Count > 0 ? string.Join(" ", insights) : $"Average retention across forms: {avgRetention:F1}%.";
+    }
+
+    private static void PrintFormCohortAnalysis(FormCohortAnalysisResult result, string format)
+    {
+        switch (format.ToLowerInvariant())
+        {
+            case "json":
+                PrintFormCohortJson(result);
+                break;
+            case "csv":
+                PrintFormCohortCsv(result);
+                break;
+            default:
+                PrintFormCohortTable(result);
+                break;
+        }
+    }
+
+    private static void PrintFormCohortTable(FormCohortAnalysisResult result)
+    {
+        Console.WriteLine();
+        Console.WriteLine($"Lead Source Analysis (Last {result.LookbackDays} Days)");
+        Console.WriteLine(new string('─', 100));
+
+        Console.WriteLine($"{"Form",-35} {"Subs",8} {"Active",8} {"Cancelled",10} {"Retention",10} {"90-Day Ret",10}");
+        Console.WriteLine(new string('─', 100));
+
+        foreach (var cohort in result.Cohorts)
+        {
+            var formName = cohort.FormName.Length > 33 ? cohort.FormName[..33] + ".." : cohort.FormName;
+            var retention90d = cohort.Retention90d.HasValue ? $"{cohort.Retention90d:F1}%" : "-";
+
+            Console.WriteLine($"{formName,-35} {cohort.TotalSubscribers,8:N0} {cohort.ActiveSubscribers,8:N0} {cohort.CancelledSubscribers,10:N0} {cohort.RetentionRate,9:F1}% {retention90d,10}");
+        }
+
+        Console.WriteLine(new string('─', 100));
+        Console.WriteLine($"{"Total",-35} {result.TotalSubscribersAnalyzed,8:N0}");
+        Console.WriteLine($"Average Retention: {result.AverageRetentionRate:F1}%");
+        Console.WriteLine();
+        Console.WriteLine($"Insight: {result.Insight}");
+    }
+
+    private static void PrintFormComparisonTable(FormCohortAnalysisResult result)
+    {
+        Console.WriteLine();
+        Console.WriteLine("Form Comparison");
+        Console.WriteLine(new string('═', 100));
+
+        // Find the max values for highlighting
+        var maxRetention = result.Cohorts.Max(c => c.RetentionRate);
+        var max90d = result.Cohorts.Where(c => c.Retention90d.HasValue).Max(c => c.Retention90d) ?? 0;
+
+        foreach (var cohort in result.Cohorts)
+        {
+            Console.WriteLine($"\n{cohort.FormName}");
+            Console.WriteLine(new string('─', 50));
+            Console.WriteLine($"  Total Subscribers:    {cohort.TotalSubscribers,10:N0}");
+            Console.WriteLine($"  Active:               {cohort.ActiveSubscribers,10:N0}");
+            Console.WriteLine($"  Cancelled:            {cohort.CancelledSubscribers,10:N0}");
+            Console.WriteLine($"  Bounced:              {cohort.BouncedSubscribers,10:N0}");
+            Console.WriteLine($"  Complained:           {cohort.ComplainedSubscribers,10:N0}");
+
+            var retentionMarker = Math.Abs(cohort.RetentionRate - maxRetention) < 0.01 ? " (best)" : "";
+            Console.WriteLine($"  Retention Rate:       {cohort.RetentionRate,9:F1}%{retentionMarker}");
+
+            if (cohort.Retention90d.HasValue)
+            {
+                var ret90dMarker = Math.Abs(cohort.Retention90d.Value - max90d) < 0.01 ? " (best)" : "";
+                Console.WriteLine($"  90-Day Retention:     {cohort.Retention90d,9:F1}%{ret90dMarker}");
+            }
+            else
+            {
+                Console.WriteLine($"  90-Day Retention:           - (insufficient data)");
+            }
+
+            Console.WriteLine($"  Recent Signups (30d): {cohort.RecentSignups30d,10:N0}");
+            Console.WriteLine($"  Recent Signups (90d): {cohort.RecentSignups90d,10:N0}");
+        }
+
+        Console.WriteLine();
+        Console.WriteLine(new string('═', 100));
+        Console.WriteLine($"Insight: {result.Insight}");
+    }
+
+    private static void PrintFormCohortJson(FormCohortAnalysisResult result)
+    {
+        var json = JsonSerializer.Serialize(result, KitJsonIndentedContext.Default.FormCohortAnalysisResult);
+        Console.WriteLine(json);
+    }
+
+    private static void PrintFormCohortCsv(FormCohortAnalysisResult result)
+    {
+        Console.WriteLine("form_id,form_name,form_type,total_subscribers,active_subscribers,cancelled_subscribers,bounced_subscribers,complained_subscribers,retention_rate,recent_signups_30d,recent_signups_90d,retention_90d,archived,created_at");
+
+        foreach (var cohort in result.Cohorts)
+        {
+            var formName = EscapeCsvField(cohort.FormName);
+            var retention90d = cohort.Retention90d.HasValue ? cohort.Retention90d.Value.ToString("F2") : "";
+
+            Console.WriteLine($"{cohort.FormId},{formName},{cohort.FormType},{cohort.TotalSubscribers},{cohort.ActiveSubscribers},{cohort.CancelledSubscribers},{cohort.BouncedSubscribers},{cohort.ComplainedSubscribers},{cohort.RetentionRate:F2},{cohort.RecentSignups30d},{cohort.RecentSignups90d},{retention90d},{cohort.Archived},{cohort.CreatedAt:yyyy-MM-dd}");
+        }
+    }
+
+    private static async Task<int> ExportFormCohortAnalysis(FormCohortAnalysisResult result, string outputPath)
+    {
+        var fileFormat = Path.GetExtension(outputPath).ToLowerInvariant() switch
+        {
+            ".json" => "json",
+            ".csv" => "csv",
+            _ => "csv"
+        };
+
+        if (!outputPath.Contains('.'))
+        {
+            outputPath += ".csv";
+        }
+
+        await using var writer = new StreamWriter(outputPath);
+
+        if (fileFormat == "json")
+        {
+            var json = JsonSerializer.Serialize(result, KitJsonIndentedContext.Default.FormCohortAnalysisResult);
+            await writer.WriteAsync(json);
+        }
+        else
+        {
+            await writer.WriteLineAsync("form_id,form_name,form_type,total_subscribers,active_subscribers,cancelled_subscribers,bounced_subscribers,complained_subscribers,retention_rate,recent_signups_30d,recent_signups_90d,retention_90d,archived,created_at");
+
+            foreach (var cohort in result.Cohorts)
+            {
+                var formName = EscapeCsvField(cohort.FormName);
+                var retention90d = cohort.Retention90d.HasValue ? cohort.Retention90d.Value.ToString("F2") : "";
+
+                await writer.WriteLineAsync($"{cohort.FormId},{formName},{cohort.FormType},{cohort.TotalSubscribers},{cohort.ActiveSubscribers},{cohort.CancelledSubscribers},{cohort.BouncedSubscribers},{cohort.ComplainedSubscribers},{cohort.RetentionRate:F2},{cohort.RecentSignups30d},{cohort.RecentSignups90d},{retention90d},{cohort.Archived},{cohort.CreatedAt:yyyy-MM-dd}");
+            }
+        }
+
+        Console.WriteLine($"Exported form cohort analysis to {outputPath}");
+        return 0;
+    }
 }

--- a/src/KitCLI/Helpers/CommandHelp.cs
+++ b/src/KitCLI/Helpers/CommandHelp.cs
@@ -493,7 +493,8 @@ public static class CommandHelp
             Subcommands = new Dictionary<string, string>
             {
                 ["by-signup"] = "Analyze engagement by signup date cohort",
-                ["by-tag"] = "Compare subscriber cohorts by tag"
+                ["by-tag"] = "Compare subscriber cohorts by tag",
+                ["by-form"] = "Analyze lead source quality by signup form"
             }
         },
         ["cohort by-signup"] = new CommandHelpInfo
@@ -533,6 +534,27 @@ public static class CommandHelp
                 "kit cohort by-tag --pattern 'lead-*'",
                 "kit cohort by-tag --tags 12345,67890 --format json",
                 "kit cohort by-tag --pattern 'course-*' --export tag-cohorts.csv"
+            }
+        },
+        ["cohort by-form"] = new CommandHelpInfo
+        {
+            Usage = "kit cohort by-form [options]",
+            Description = "Analyze lead source quality by signup form. Compares retention and engagement metrics for subscribers from different forms.",
+            Options = new Dictionary<string, string>
+            {
+                ["--form-ids <ids>"] = "Comma-separated form IDs to analyze (default: all forms)",
+                ["--days, -d <days>"] = "Lookback days (default: 365)",
+                ["--compare"] = "Head-to-head comparison of two forms",
+                ["--include-archived"] = "Include archived forms in analysis",
+                ["--format, -f <format>"] = "Output format: table (default), json, csv",
+                ["--export <path>"] = "Export to file (CSV or JSON based on extension)"
+            },
+            Examples = new[]
+            {
+                "kit cohort by-form",
+                "kit cohort by-form --form-ids 12345,67890 --compare",
+                "kit cohort by-form --days 180 --format json",
+                "kit cohort by-form --include-archived --export form-cohorts.csv"
             }
         }
     };

--- a/src/KitCLI/KitJsonContext.cs
+++ b/src/KitCLI/KitJsonContext.cs
@@ -98,6 +98,9 @@ namespace KitCLI;
 [JsonSerializable(typeof(TagCohort))]
 [JsonSerializable(typeof(TagCohort[]))]
 [JsonSerializable(typeof(TagCohortAnalysisResult))]
+[JsonSerializable(typeof(FormCohort))]
+[JsonSerializable(typeof(FormCohort[]))]
+[JsonSerializable(typeof(FormCohortAnalysisResult))]
 public partial class KitJsonContext : JsonSerializerContext
 {
 }
@@ -143,6 +146,9 @@ public partial class KitJsonContext : JsonSerializerContext
 [JsonSerializable(typeof(TagCohort))]
 [JsonSerializable(typeof(TagCohort[]))]
 [JsonSerializable(typeof(TagCohortAnalysisResult))]
+[JsonSerializable(typeof(FormCohort))]
+[JsonSerializable(typeof(FormCohort[]))]
+[JsonSerializable(typeof(FormCohortAnalysisResult))]
 public partial class KitJsonIndentedContext : JsonSerializerContext
 {
 }

--- a/src/KitCLI/Models/CohortAnalysis.cs
+++ b/src/KitCLI/Models/CohortAnalysis.cs
@@ -235,3 +235,153 @@ public sealed class TagCohortAnalysisResult
     [JsonPropertyName("insight")]
     public string Insight { get; set; } = string.Empty;
 }
+
+/// <summary>
+/// Represents a cohort of subscribers grouped by signup form.
+/// </summary>
+public sealed class FormCohort
+{
+    /// <summary>
+    /// The form ID
+    /// </summary>
+    [JsonPropertyName("form_id")]
+    public long FormId { get; set; }
+
+    /// <summary>
+    /// The form name
+    /// </summary>
+    [JsonPropertyName("form_name")]
+    public string FormName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The form type (e.g., "embed", "hosted", "modal")
+    /// </summary>
+    [JsonPropertyName("form_type")]
+    public string FormType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Total subscribers from this form
+    /// </summary>
+    [JsonPropertyName("total_subscribers")]
+    public int TotalSubscribers { get; set; }
+
+    /// <summary>
+    /// Currently active subscribers from this form
+    /// </summary>
+    [JsonPropertyName("active_subscribers")]
+    public int ActiveSubscribers { get; set; }
+
+    /// <summary>
+    /// Subscribers who have cancelled from this form
+    /// </summary>
+    [JsonPropertyName("cancelled_subscribers")]
+    public int CancelledSubscribers { get; set; }
+
+    /// <summary>
+    /// Subscribers who bounced from this form
+    /// </summary>
+    [JsonPropertyName("bounced_subscribers")]
+    public int BouncedSubscribers { get; set; }
+
+    /// <summary>
+    /// Subscribers who complained from this form
+    /// </summary>
+    [JsonPropertyName("complained_subscribers")]
+    public int ComplainedSubscribers { get; set; }
+
+    /// <summary>
+    /// Retention rate (active / total) as percentage 0-100
+    /// </summary>
+    [JsonPropertyName("retention_rate")]
+    public double RetentionRate { get; set; }
+
+    /// <summary>
+    /// Subscribers who signed up in the last 30 days
+    /// </summary>
+    [JsonPropertyName("recent_signups_30d")]
+    public int RecentSignups30d { get; set; }
+
+    /// <summary>
+    /// Subscribers who signed up in the last 90 days
+    /// </summary>
+    [JsonPropertyName("recent_signups_90d")]
+    public int RecentSignups90d { get; set; }
+
+    /// <summary>
+    /// 90-day retention: % of subscribers from 90+ days ago still active
+    /// </summary>
+    [JsonPropertyName("retention_90d")]
+    public double? Retention90d { get; set; }
+
+    /// <summary>
+    /// Whether the form is archived
+    /// </summary>
+    [JsonPropertyName("archived")]
+    public bool Archived { get; set; }
+
+    /// <summary>
+    /// When the form was created
+    /// </summary>
+    [JsonPropertyName("created_at")]
+    public DateTime CreatedAt { get; set; }
+}
+
+/// <summary>
+/// Complete result of a form-based cohort analysis.
+/// </summary>
+public sealed class FormCohortAnalysisResult
+{
+    /// <summary>
+    /// Type of analysis performed
+    /// </summary>
+    [JsonPropertyName("analysis_type")]
+    public string AnalysisType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Number of forms analyzed
+    /// </summary>
+    [JsonPropertyName("form_count")]
+    public int FormCount { get; set; }
+
+    /// <summary>
+    /// Total subscribers analyzed across all forms
+    /// </summary>
+    [JsonPropertyName("total_subscribers_analyzed")]
+    public int TotalSubscribersAnalyzed { get; set; }
+
+    /// <summary>
+    /// Number of days analyzed
+    /// </summary>
+    [JsonPropertyName("lookback_days")]
+    public int LookbackDays { get; set; }
+
+    /// <summary>
+    /// The form cohorts with their analysis data
+    /// </summary>
+    [JsonPropertyName("cohorts")]
+    public FormCohort[] Cohorts { get; set; } = [];
+
+    /// <summary>
+    /// Auto-generated insight about the data
+    /// </summary>
+    [JsonPropertyName("insight")]
+    public string Insight { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Average retention rate across all forms
+    /// </summary>
+    [JsonPropertyName("average_retention_rate")]
+    public double AverageRetentionRate { get; set; }
+
+    /// <summary>
+    /// Best performing form by retention
+    /// </summary>
+    [JsonPropertyName("best_form")]
+    public string? BestForm { get; set; }
+
+    /// <summary>
+    /// Worst performing form by retention
+    /// </summary>
+    [JsonPropertyName("worst_form")]
+    public string? WorstForm { get; set; }
+}

--- a/src/KitCLI/Program.cs
+++ b/src/KitCLI/Program.cs
@@ -843,6 +843,7 @@ static async Task<int> HandleCohortCommand(string[] args, bool isReadOnly)
     {
         "by-signup" => await CohortCommands.HandleBySignup(args[1..], client),
         "by-tag" => await CohortCommands.HandleByTag(args[1..], client),
+        "by-form" => await CohortCommands.HandleByForm(args[1..], client),
         _ => ShowUnknownCommand($"cohort {args[0]}")
     };
 }

--- a/src/KitCLI/Services/KitApiClient.cs
+++ b/src/KitCLI/Services/KitApiClient.cs
@@ -88,7 +88,7 @@ public interface IKitApiClient
     Task<SequenceStats?> GetSequenceStatsAsync(long sequenceId, CancellationToken cancellationToken = default);
 
     // Forms
-    Task<PaginatedResponse<Form>> GetFormsAsync(
+    Task<FormsResponse> GetFormsAsync(
         int perPage = 50,
         string? after = null,
         CancellationToken cancellationToken = default);
@@ -726,7 +726,7 @@ public sealed class KitApiClient : IKitApiClient, IDisposable
     }
 
     // Forms
-    public async Task<PaginatedResponse<Form>> GetFormsAsync(
+    public async Task<FormsResponse> GetFormsAsync(
         int perPage = 50,
         string? after = null,
         CancellationToken cancellationToken = default)
@@ -741,8 +741,8 @@ public sealed class KitApiClient : IKitApiClient, IDisposable
         response.EnsureSuccessStatusCode();
 
         var json = await response.Content.ReadAsStringAsync(cancellationToken);
-        return JsonSerializer.Deserialize<PaginatedResponse<Form>>(json, KitJsonContext.Default.PaginatedResponseForm)
-               ?? new PaginatedResponse<Form>();
+        return JsonSerializer.Deserialize<FormsResponse>(json, KitJsonContext.Default.FormsResponse)
+               ?? new FormsResponse();
     }
 
     public async IAsyncEnumerable<Form> GetAllFormsAsync(
@@ -756,7 +756,7 @@ public sealed class KitApiClient : IKitApiClient, IDisposable
         {
             var response = await GetFormsAsync(50, after, cancellationToken);
 
-            foreach (var form in response.Data)
+            foreach (var form in response.Forms)
             {
                 if (retrieved >= limit)
                 {


### PR DESCRIPTION
## Summary
- Adds `kit cohort by-form` command to analyze lead source quality by signup form
- Identifies which forms produce the most engaged/retained subscribers
- Supports filtering by specific form IDs, lookback days, and archived forms
- Includes comparison mode for head-to-head form analysis
- Supports table, JSON, and CSV output formats with export option

## Changes
- Added `FormCohort` and `FormCohortAnalysisResult` models in `CohortAnalysis.cs`
- Implemented `HandleByForm` method in `CohortCommands.cs` (~450 lines)
- Added routing in `Program.cs` for the new subcommand
- Added JSON context registrations for AOT compatibility
- Added help entries in `CommandHelp.cs`
- **Fixed `GetFormsAsync`** to use `FormsResponse` instead of `PaginatedResponse<Form>` - the Kit API returns forms in a `forms` array, not a `data` array

## Test plan
- [x] Build succeeds
- [x] `kit cohort by-form --help` shows correct options
- [x] `kit cohort by-form` lists all forms with metrics
- [x] `--format json` outputs valid JSON
- [x] `--format csv` outputs valid CSV
- [x] `--export` saves to file correctly
- [x] All 115 unit tests pass

Closes #65