### PR TITLE
fix: Remove misleading subscriber/email columns from sequence list

### DIFF
--- a/src/KitCLI/Commands/SequenceCommands.cs
+++ b/src/KitCLI/Commands/SequenceCommands.cs
@@ -399,27 +399,29 @@ public static class SequenceCommands
         }
 
         // Table format
+        // Note: Kit V4 API list endpoint only returns id, name, hold, repeat, created_at
+        // Use 'kit sequence stats <id>' or 'kit sequence analyze <id>' for subscriber/email counts
         const int idWidth = 10;
-        const int nameWidth = 35;
-        const int subsWidth = 12;
-        const int emailsWidth = 8;
+        const int nameWidth = 40;
         const int statusWidth = 10;
+        const int createdWidth = 12;
 
-        Console.WriteLine(new string('─', idWidth + nameWidth + subsWidth + emailsWidth + statusWidth + 10));
-        Console.WriteLine($"│ {"ID",-idWidth} │ {"Name",-nameWidth} │ {"Subscribers",subsWidth} │ {"Emails",emailsWidth} │ {"Status",-statusWidth} │");
-        Console.WriteLine(new string('─', idWidth + nameWidth + subsWidth + emailsWidth + statusWidth + 10));
+        Console.WriteLine(new string('─', idWidth + nameWidth + statusWidth + createdWidth + 8));
+        Console.WriteLine($"│ {"ID",-idWidth} │ {"Name",-nameWidth} │ {"Status",-statusWidth} │ {"Created",createdWidth} │");
+        Console.WriteLine(new string('─', idWidth + nameWidth + statusWidth + createdWidth + 8));
 
         foreach (var sequence in sequenceList.OrderBy(s => s.Name))
         {
             var name = TruncateString(sequence.Name, nameWidth);
             var status = sequence.Hold ? "On Hold" : "Active";
+            var created = sequence.CreatedAt.ToString("yyyy-MM-dd");
 
-            // Note: Kit V4 API doesn't return subscriber_count for sequences
-            Console.WriteLine($"│ {sequence.Id,-idWidth} │ {name,-nameWidth} │ {"N/A",subsWidth} │ {sequence.EmailCount,emailsWidth} │ {status,-statusWidth} │");
+            Console.WriteLine($"│ {sequence.Id,-idWidth} │ {name,-nameWidth} │ {status,-statusWidth} │ {created,createdWidth} │");
         }
 
-        Console.WriteLine(new string('─', idWidth + nameWidth + subsWidth + emailsWidth + statusWidth + 10));
+        Console.WriteLine(new string('─', idWidth + nameWidth + statusWidth + createdWidth + 8));
         Console.WriteLine($"Total: {sequenceList.Count:N0} sequence(s)");
+        Console.WriteLine("\nTip: Use 'kit sequence stats <id>' for subscriber and email counts.");
     }
 
     private static void PrintSequenceEmails(IEnumerable<SequenceEmail> emails)

--- a/src/KitCLI/Helpers/CommandHelp.cs
+++ b/src/KitCLI/Helpers/CommandHelp.cs
@@ -473,6 +473,45 @@ public static class CommandHelp
                 ["analyze"] = "Analyze sequence performance"
             }
         },
+        ["sequence list"] = new CommandHelpInfo
+        {
+            Usage = "kit sequence list [options]",
+            Description = "List all email sequences. Note: Kit API does not return subscriber/email counts in the list response - use 'kit sequence stats <id>' for detailed metrics.",
+            Options = new Dictionary<string, string>
+            {
+                ["--limit, -l <number>"] = "Maximum results (default: 50)",
+                ["--format, -f <format>"] = "Output format: table (default), json"
+            },
+            Examples = new[]
+            {
+                "kit sequence list",
+                "kit sequence list --limit 100",
+                "kit sequence list --format json"
+            }
+        },
+        ["sequence get"] = new CommandHelpInfo
+        {
+            Usage = "kit sequence get <id> [options]",
+            Description = "Get details for a specific sequence",
+            Options = new Dictionary<string, string>
+            {
+                ["--format, -f <format>"] = "Output format: table (default), json"
+            },
+            Examples = new[]
+            {
+                "kit sequence get 12345",
+                "kit sequence get 12345 --format json"
+            }
+        },
+        ["sequence stats"] = new CommandHelpInfo
+        {
+            Usage = "kit sequence stats <id>",
+            Description = "Display sequence statistics including subscriber counts and email performance",
+            Examples = new[]
+            {
+                "kit sequence stats 12345"
+            }
+        },
         ["form"] = new CommandHelpInfo
         {
             Usage = "kit form <subcommand> [options]",


### PR DESCRIPTION
## Summary
The Kit API v4 list sequences endpoint only returns basic fields (id, name, hold, repeat, created_at) - not `subscriber_count` or `email_count`. This was causing the list to display "N/A" and "0" which was confusing for users.

## Changes
- Remove Subscribers and Emails columns from table display
- Add Created column using available data
- Add helpful tip directing users to `kit sequence stats` for counts
- Add help entries for `sequence list`, `sequence get`, and `sequence stats` commands

## Before
```
│ ID         │ Name                                │ Subscribers │ Emails │ Status     │
│ 123456     │ Welcome Sequence                    │         N/A │      0 │ Active     │
```

## After
```
│ ID         │ Name                                     │ Status     │      Created │
│ 123456     │ Welcome Sequence                         │ Active     │   2024-01-15 │

Total: 1 sequence(s)

Tip: Use 'kit sequence stats <id>' for subscriber and email counts.
```

## Test plan
- [x] Build passes
- [x] Tests pass
- [ ] Manual test with `kit sequence list`
- [ ] Verify help: `kit sequence list --help`

Fixes #98