### PR TITLE
feat: Add kit form compare command (#101)

### DIFF
--- a/src/KitCLI/Commands/FormCommands.cs
+++ b/src/KitCLI/Commands/FormCommands.cs
@@ -161,6 +161,247 @@ public static class FormCommands
         }
     }
 
+    public static async Task<int> HandleCompare(string[] args, IKitApiClient client)
+    {
+        var formIds = new List<long>();
+        string format = "table";
+        string? exportPath = null;
+
+        // Parse form IDs and options
+        for (int i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--format":
+                case "-f":
+                    if (i + 1 < args.Length)
+                    {
+                        format = args[++i].ToLowerInvariant();
+                    }
+                    break;
+                case "--export":
+                case "-o":
+                    if (i + 1 < args.Length)
+                    {
+                        exportPath = args[++i];
+                    }
+                    break;
+                default:
+                    // Try to parse as form ID
+                    if (long.TryParse(args[i], out var formId))
+                    {
+                        formIds.Add(formId);
+                    }
+                    break;
+            }
+        }
+
+        if (formIds.Count < 2)
+        {
+            Console.Error.WriteLine("❌ At least 2 form IDs are required for comparison");
+            Console.WriteLine("Usage: kit form compare <id1> <id2> [id3...] [options]");
+            Console.WriteLine("Options:");
+            Console.WriteLine("  --format, -f <format>   Output format: table (default), json, csv");
+            Console.WriteLine("  --export, -o <path>     Export to file");
+            return 1;
+        }
+
+        using var progress = new ProgressIndicator($"Comparing {formIds.Count} forms...");
+
+        // Fetch forms and their subscribers in parallel
+        var comparisonItems = new List<FormComparisonItem>();
+
+        foreach (var id in formIds)
+        {
+            var form = await client.GetFormAsync(id);
+            if (form == null)
+            {
+                Console.Error.WriteLine($"⚠ Form {id} not found, skipping");
+                continue;
+            }
+
+            var subscribers = new List<Subscriber>();
+            await foreach (var sub in client.GetAllFormSubscribersAsync(id, 1000))
+            {
+                subscribers.Add(sub);
+            }
+
+            var now = DateTime.UtcNow;
+            var thirtyDaysAgo = now.AddDays(-30);
+            var ninetyDaysAgo = now.AddDays(-90);
+
+            var activeCount = subscribers.Count(s => s.State.Equals("active", StringComparison.OrdinalIgnoreCase));
+            var cancelledCount = subscribers.Count(s => s.State.Equals("cancelled", StringComparison.OrdinalIgnoreCase));
+            var bouncedCount = subscribers.Count(s => s.State.Equals("bounced", StringComparison.OrdinalIgnoreCase));
+            var complainedCount = subscribers.Count(s => s.State.Equals("complained", StringComparison.OrdinalIgnoreCase));
+            var signups30d = subscribers.Count(s => s.CreatedAt >= thirtyDaysAgo);
+            var signups90d = subscribers.Count(s => s.CreatedAt >= ninetyDaysAgo);
+
+            var ageDays = (int)(now - form.CreatedAt).TotalDays;
+            var dailyAverage = ageDays > 0 ? (double)subscribers.Count / ageDays : 0;
+
+            comparisonItems.Add(new FormComparisonItem
+            {
+                FormId = form.Id,
+                FormName = form.Name ?? $"Form {form.Id}",
+                FormType = form.Type ?? "unknown",
+                TotalSubscribers = subscribers.Count,
+                ActiveSubscribers = activeCount,
+                CancelledSubscribers = cancelledCount,
+                BouncedSubscribers = bouncedCount,
+                ComplainedSubscribers = complainedCount,
+                RetentionRate = subscribers.Count > 0 ? (double)activeCount / subscribers.Count * 100 : 0,
+                Signups30d = signups30d,
+                Signups90d = signups90d,
+                DailyAverage = dailyAverage,
+                CreatedAt = form.CreatedAt,
+                AgeDays = ageDays,
+                Archived = form.Archived
+            });
+        }
+
+        if (comparisonItems.Count < 2)
+        {
+            progress.Complete("Not enough forms found for comparison");
+            Console.Error.WriteLine("❌ Need at least 2 valid forms for comparison");
+            return 1;
+        }
+
+        progress.Complete($"Comparing {comparisonItems.Count} forms");
+
+        // Determine winner (highest subscriber count with best retention)
+        var winner = comparisonItems
+            .OrderByDescending(f => f.TotalSubscribers)
+            .ThenByDescending(f => f.RetentionRate)
+            .First();
+
+        var winnerReason = $"highest subscriber count ({winner.TotalSubscribers:N0}) and {winner.RetentionRate:F1}% retention";
+
+        var result = new FormComparisonResult
+        {
+            Forms = comparisonItems.ToArray(),
+            WinnerFormId = winner.FormId,
+            WinnerFormName = winner.FormName,
+            WinnerReason = winnerReason
+        };
+
+        // Output
+        if (!string.IsNullOrEmpty(exportPath))
+        {
+            await ExportComparison(result, exportPath);
+            Console.WriteLine($"✓ Comparison exported to {exportPath}");
+        }
+
+        switch (format)
+        {
+            case "json":
+                var json = JsonSerializer.Serialize(result, KitJsonIndentedContext.Default.FormComparisonResult);
+                Console.WriteLine(json);
+                break;
+            case "csv":
+                PrintComparisonCsv(result);
+                break;
+            default:
+                PrintComparisonTable(result);
+                break;
+        }
+
+        return 0;
+    }
+
+    private static void PrintComparisonTable(FormComparisonResult result)
+    {
+        var forms = result.Forms;
+        var colWidth = Math.Max(15, forms.Max(f => f.FormName.Length) + 2);
+
+        Console.WriteLine();
+        Console.WriteLine("═══════════════════════════════════════════════════════════════════════════════");
+        Console.WriteLine("  FORM COMPARISON");
+        Console.WriteLine("═══════════════════════════════════════════════════════════════════════════════");
+        Console.WriteLine();
+
+        // Header with form names
+        Console.Write($"  {"Metric",-20}");
+        foreach (var form in forms)
+        {
+            var name = form.FormName.Length > colWidth - 2 ? form.FormName[..(colWidth - 5)] + "..." : form.FormName;
+            Console.Write($"  {name.PadLeft(colWidth)}");
+        }
+        Console.WriteLine();
+        Console.WriteLine($"  {new string('─', 20 + (colWidth + 2) * forms.Length)}");
+
+        // Subscriber counts
+        PrintComparisonRow("Total Subscribers", forms.Select(f => f.TotalSubscribers.ToString("N0")), colWidth);
+        PrintComparisonRow("Active", forms.Select(f => f.ActiveSubscribers.ToString("N0")), colWidth);
+        PrintComparisonRow("Cancelled", forms.Select(f => f.CancelledSubscribers.ToString("N0")), colWidth);
+        PrintComparisonRow("Bounced", forms.Select(f => f.BouncedSubscribers.ToString("N0")), colWidth);
+        PrintComparisonRow("Retention Rate", forms.Select(f => $"{f.RetentionRate:F1}%"), colWidth);
+
+        Console.WriteLine($"  {new string('─', 20 + (colWidth + 2) * forms.Length)}");
+
+        // Activity metrics
+        PrintComparisonRow("Signups (30d)", forms.Select(f => f.Signups30d.ToString("N0")), colWidth);
+        PrintComparisonRow("Signups (90d)", forms.Select(f => f.Signups90d.ToString("N0")), colWidth);
+        PrintComparisonRow("Daily Average", forms.Select(f => f.DailyAverage.ToString("F1")), colWidth);
+
+        Console.WriteLine($"  {new string('─', 20 + (colWidth + 2) * forms.Length)}");
+
+        // Form info
+        PrintComparisonRow("Form Type", forms.Select(f => f.FormType), colWidth);
+        PrintComparisonRow("Created", forms.Select(f => f.CreatedAt.ToString("yyyy-MM-dd")), colWidth);
+        PrintComparisonRow("Age (days)", forms.Select(f => f.AgeDays.ToString("N0")), colWidth);
+
+        Console.WriteLine();
+        Console.WriteLine($"═══════════════════════════════════════════════════════════════════════════════");
+        Console.WriteLine();
+        Console.WriteLine($"  Winner: \"{result.WinnerFormName}\" - {result.WinnerReason}");
+        Console.WriteLine();
+    }
+
+    private static void PrintComparisonRow(string label, IEnumerable<string> values, int colWidth)
+    {
+        Console.Write($"  {label,-20}");
+        foreach (var value in values)
+        {
+            Console.Write($"  {value.PadLeft(colWidth)}");
+        }
+        Console.WriteLine();
+    }
+
+    private static void PrintComparisonCsv(FormComparisonResult result)
+    {
+        Console.WriteLine("form_id,form_name,form_type,total_subscribers,active_subscribers,cancelled_subscribers,bounced_subscribers,retention_rate,signups_30d,signups_90d,daily_average,created_at,age_days");
+
+        foreach (var form in result.Forms)
+        {
+            var name = EscapeCsvField(form.FormName);
+            Console.WriteLine($"{form.FormId},{name},{form.FormType},{form.TotalSubscribers},{form.ActiveSubscribers},{form.CancelledSubscribers},{form.BouncedSubscribers},{form.RetentionRate:F2},{form.Signups30d},{form.Signups90d},{form.DailyAverage:F2},{form.CreatedAt:yyyy-MM-dd},{form.AgeDays}");
+        }
+    }
+
+    private static async Task ExportComparison(FormComparisonResult result, string path)
+    {
+        var extension = Path.GetExtension(path).ToLowerInvariant();
+
+        await using var writer = new StreamWriter(path);
+
+        if (extension == ".json")
+        {
+            var json = JsonSerializer.Serialize(result, KitJsonIndentedContext.Default.FormComparisonResult);
+            await writer.WriteAsync(json);
+        }
+        else // CSV
+        {
+            await writer.WriteLineAsync("form_id,form_name,form_type,total_subscribers,active_subscribers,cancelled_subscribers,bounced_subscribers,retention_rate,signups_30d,signups_90d,daily_average,created_at,age_days");
+
+            foreach (var form in result.Forms)
+            {
+                var name = EscapeCsvField(form.FormName);
+                await writer.WriteLineAsync($"{form.FormId},{name},{form.FormType},{form.TotalSubscribers},{form.ActiveSubscribers},{form.CancelledSubscribers},{form.BouncedSubscribers},{form.RetentionRate:F2},{form.Signups30d},{form.Signups90d},{form.DailyAverage:F2},{form.CreatedAt:yyyy-MM-dd},{form.AgeDays}");
+            }
+        }
+    }
+
     private static void PrintForms(IEnumerable<Form> forms, string format)
     {
         var formList = forms.ToList();

--- a/src/KitCLI/Helpers/CommandHelp.cs
+++ b/src/KitCLI/Helpers/CommandHelp.cs
@@ -481,7 +481,24 @@ public static class CommandHelp
             {
                 ["list"] = "List all forms",
                 ["get"] = "Get form details",
-                ["subscribers"] = "Get form subscribers"
+                ["subscribers"] = "Get form subscribers",
+                ["compare"] = "Compare performance of multiple forms"
+            }
+        },
+        ["form compare"] = new CommandHelpInfo
+        {
+            Usage = "kit form compare <id1> <id2> [id3...] [options]",
+            Description = "Compare performance metrics of multiple forms. Analyzes subscriber counts, retention rates, recent signups, and daily averages to determine the best performing form.",
+            Options = new Dictionary<string, string>
+            {
+                ["--format, -f <format>"] = "Output format: table (default), json, csv",
+                ["--export, -o <path>"] = "Export to file (CSV or JSON based on extension)"
+            },
+            Examples = new[]
+            {
+                "kit form compare 12345 67890",
+                "kit form compare 111 222 333 --format json",
+                "kit form compare 12345 67890 --export comparison.csv"
             }
         },
         ["export"] = new CommandHelpInfo

--- a/src/KitCLI/KitJsonContext.cs
+++ b/src/KitCLI/KitJsonContext.cs
@@ -104,6 +104,9 @@ namespace KitCLI;
 [JsonSerializable(typeof(BroadcastTrendPeriod))]
 [JsonSerializable(typeof(BroadcastTrendPeriod[]))]
 [JsonSerializable(typeof(BroadcastTrendResult))]
+[JsonSerializable(typeof(FormComparisonItem))]
+[JsonSerializable(typeof(FormComparisonItem[]))]
+[JsonSerializable(typeof(FormComparisonResult))]
 public partial class KitJsonContext : JsonSerializerContext
 {
 }
@@ -155,6 +158,9 @@ public partial class KitJsonContext : JsonSerializerContext
 [JsonSerializable(typeof(BroadcastTrendPeriod))]
 [JsonSerializable(typeof(BroadcastTrendPeriod[]))]
 [JsonSerializable(typeof(BroadcastTrendResult))]
+[JsonSerializable(typeof(FormComparisonItem))]
+[JsonSerializable(typeof(FormComparisonItem[]))]
+[JsonSerializable(typeof(FormComparisonResult))]
 public partial class KitJsonIndentedContext : JsonSerializerContext
 {
 }

--- a/src/KitCLI/Models/CohortAnalysis.cs
+++ b/src/KitCLI/Models/CohortAnalysis.cs
@@ -385,3 +385,72 @@ public sealed class FormCohortAnalysisResult
     [JsonPropertyName("worst_form")]
     public string? WorstForm { get; set; }
 }
+
+/// <summary>
+/// Represents a form with its comparison metrics.
+/// </summary>
+public sealed class FormComparisonItem
+{
+    [JsonPropertyName("form_id")]
+    public long FormId { get; set; }
+
+    [JsonPropertyName("form_name")]
+    public string FormName { get; set; } = string.Empty;
+
+    [JsonPropertyName("form_type")]
+    public string FormType { get; set; } = string.Empty;
+
+    [JsonPropertyName("total_subscribers")]
+    public int TotalSubscribers { get; set; }
+
+    [JsonPropertyName("active_subscribers")]
+    public int ActiveSubscribers { get; set; }
+
+    [JsonPropertyName("cancelled_subscribers")]
+    public int CancelledSubscribers { get; set; }
+
+    [JsonPropertyName("bounced_subscribers")]
+    public int BouncedSubscribers { get; set; }
+
+    [JsonPropertyName("complained_subscribers")]
+    public int ComplainedSubscribers { get; set; }
+
+    [JsonPropertyName("retention_rate")]
+    public double RetentionRate { get; set; }
+
+    [JsonPropertyName("signups_30d")]
+    public int Signups30d { get; set; }
+
+    [JsonPropertyName("signups_90d")]
+    public int Signups90d { get; set; }
+
+    [JsonPropertyName("daily_average")]
+    public double DailyAverage { get; set; }
+
+    [JsonPropertyName("created_at")]
+    public DateTime CreatedAt { get; set; }
+
+    [JsonPropertyName("age_days")]
+    public int AgeDays { get; set; }
+
+    [JsonPropertyName("archived")]
+    public bool Archived { get; set; }
+}
+
+/// <summary>
+/// Complete result of a form comparison.
+/// </summary>
+public sealed class FormComparisonResult
+{
+    [JsonPropertyName("forms")]
+    public FormComparisonItem[] Forms { get; set; } = [];
+
+    [JsonPropertyName("winner_form_id")]
+    public long? WinnerFormId { get; set; }
+
+    [JsonPropertyName("winner_form_name")]
+    public string? WinnerFormName { get; set; }
+
+    [JsonPropertyName("winner_reason")]
+    public string? WinnerReason { get; set; }
+}

--- a/src/KitCLI/Program.cs
+++ b/src/KitCLI/Program.cs
@@ -799,6 +799,7 @@ static async Task<int> HandleFormCommand(string[] args, bool isReadOnly)
         "list" => await FormCommands.HandleList(args[1..], client),
         "get" => await FormCommands.HandleGet(args[1..], client),
         "subscribers" => await FormCommands.HandleSubscribers(args[1..], client),
+        "compare" => await FormCommands.HandleCompare(args[1..], client),
         _ => ShowUnknownCommand($"form {args[0]}")
     };
 }


### PR DESCRIPTION
## Summary

Implements issue #101 - head-to-head comparison of form performance.

### Features

- Compare 2+ forms by subscriber metrics
- Shows total subscribers, active/cancelled/bounced counts
- Calculates retention rates and daily average signups
- Tracks recent signups (30d and 90d)
- Shows form age and creation date
- Determines winner based on total subscribers and retention rate
- Supports table, json, csv output formats
- Export to file option

### Usage

```bash
# Compare two forms
kit form compare 12345 67890

# Compare multiple forms with JSON output
kit form compare 111 222 333 --format json

# Export comparison to CSV
kit form compare 12345 67890 --export comparison.csv
```

### Example Output

```
═══════════════════════════════════════════════════════════════════════════════
  FORM COMPARISON
═══════════════════════════════════════════════════════════════════════════════

  Metric                Newsletter Form    Landing Page    Popup Form
  ─────────────────────────────────────────────────────────────────────────────
  Total Subscribers          1,500            2,300            800
  Active                     1,200            1,900            650
  Cancelled                    250              350            120
  Bounced                       50               50             30
  Retention Rate              80.0%            82.6%          81.3%
  ─────────────────────────────────────────────────────────────────────────────
  Signups (30d)                 45               72             25
  Signups (90d)                120              180             65
  Daily Average               4.1              6.3            2.2

  Winner: "Landing Page" - highest subscriber count (2,300) and 82.6% retention
```

Closes #101