### PR TITLE
fix: Address v1.2.0 bug reports (#112, #113, #114, #115)

### DIFF
--- a/src/KitCLI.Tests/Mocks/MockKitApiClient.cs
+++ b/src/KitCLI.Tests/Mocks/MockKitApiClient.cs
@@ -11,7 +11,7 @@ namespace KitCLI.Tests.Mocks;
 public sealed class MockKitApiClient : IKitApiClient
 {
     // Subscribers
-    public Func<int, string?, CancellationToken, Task<PaginatedResponse<Subscriber>>>? GetSubscribersAsyncFunc { get; set; }
+    public Func<int, string?, string?, CancellationToken, Task<PaginatedResponse<Subscriber>>>? GetSubscribersAsyncFunc { get; set; }
     public Func<string?, CancellationToken, IAsyncEnumerable<Subscriber>>? GetAllSubscribersAsyncFunc { get; set; }
     public Func<long, CancellationToken, Task<Subscriber?>>? GetSubscriberAsyncFunc { get; set; }
     public Func<string, CancellationToken, Task<Subscriber?>>? GetSubscriberByEmailAsyncFunc { get; set; }
@@ -65,16 +65,20 @@ public sealed class MockKitApiClient : IKitApiClient
 
     // Subscribers
     public Task<PaginatedResponse<Subscriber>> GetSubscribersAsync(
-        int perPage = 50, string? after = null, CancellationToken cancellationToken = default)
+        int perPage = 50, string? after = null, string? state = null, CancellationToken cancellationToken = default)
     {
         if (GetSubscribersAsyncFunc != null)
         {
-            return GetSubscribersAsyncFunc(perPage, after, cancellationToken);
+            return GetSubscribersAsyncFunc(perPage, after, state, cancellationToken);
         }
+
+        var filtered = state != null
+            ? Subscribers.Where(s => s.State.Equals(state, StringComparison.OrdinalIgnoreCase))
+            : Subscribers;
 
         return Task.FromResult(new PaginatedResponse<Subscriber>
         {
-            Data = Subscribers.Take(perPage).ToArray(),
+            Data = filtered.Take(perPage).ToArray(),
             Pagination = new PaginationInfo { HasNextPage = false }
         });
     }

--- a/src/KitCLI.Tests/Models/SubscriberTests.cs
+++ b/src/KitCLI.Tests/Models/SubscriberTests.cs
@@ -106,4 +106,80 @@ public class SubscriberTests
         // Act & Assert
         subscriber.TagList.Should().BeEmpty();
     }
+
+    /// <summary>
+    /// Regression test for #115: JSON serialization error with Fields property.
+    /// The Fields property must be Dictionary&lt;string, JsonElement&gt; for AOT compatibility.
+    /// </summary>
+    [Fact]
+    public void Subscriber_Should_Serialize_With_Fields_Property()
+    {
+        // Arrange - create subscriber with fields containing various JSON types
+        var json = """
+            {
+                "id": 12345,
+                "email_address": "test@example.com",
+                "first_name": "John",
+                "state": "active",
+                "created_at": "2024-01-15T10:30:00Z",
+                "fields": {
+                    "custom_field": "value",
+                    "number_field": 42,
+                    "bool_field": true
+                }
+            }
+            """;
+
+        // Act - deserialize and re-serialize (this is what --format json does)
+        var subscriber = JsonSerializer.Deserialize(json, KitJsonContext.Default.Subscriber);
+        subscriber.Should().NotBeNull();
+        subscriber!.Fields.Should().NotBeNull();
+        subscriber.Fields!.Should().HaveCount(3);
+
+        // This was failing in #115 because Dictionary<string, object> can't be serialized with AOT
+        var serialized = JsonSerializer.Serialize(subscriber, KitJsonIndentedContext.Default.Subscriber);
+        serialized.Should().NotBeNullOrEmpty();
+
+        // Verify the fields are in the output
+        serialized.Should().Contain("custom_field");
+        serialized.Should().Contain("number_field");
+    }
+
+    /// <summary>
+    /// Regression test for #115: Ensure array output format works with Fields.
+    /// </summary>
+    [Fact]
+    public void SubscriberArray_Should_Serialize_With_Fields_Property()
+    {
+        // Arrange
+        var json = """
+            [
+                {
+                    "id": 1,
+                    "email_address": "test1@example.com",
+                    "state": "active",
+                    "created_at": "2024-01-15T10:30:00Z",
+                    "fields": {"company": "Acme Inc"}
+                },
+                {
+                    "id": 2,
+                    "email_address": "test2@example.com",
+                    "state": "active",
+                    "created_at": "2024-01-15T10:30:00Z",
+                    "fields": null
+                }
+            ]
+            """;
+
+        // Act
+        var subscribers = JsonSerializer.Deserialize(json, KitJsonContext.Default.SubscriberArray);
+        subscribers.Should().NotBeNull();
+        subscribers!.Should().HaveCount(2);
+
+        // This should not throw (was causing #115)
+        var serialized = JsonSerializer.Serialize(subscribers, KitJsonIndentedContext.Default.SubscriberArray);
+        serialized.Should().NotBeNullOrEmpty();
+        serialized.Should().Contain("test1@example.com");
+        serialized.Should().Contain("test2@example.com");
+    }
 }

--- a/src/KitCLI.Tests/Services/KitApiClientTests.cs
+++ b/src/KitCLI.Tests/Services/KitApiClientTests.cs
@@ -209,4 +209,187 @@ public class KitApiClientTests
         accountCalled.Should().BeTrue();
         subscribersCalled.Should().BeTrue();
     }
+
+    /// <summary>
+    /// Regression test for #113: Cancelled subscriber list returns 0 results.
+    /// The state parameter must be passed to the API as 'status' query parameter.
+    /// </summary>
+    [Fact]
+    public async Task GetSubscribersAsync_Should_Pass_State_Parameter_To_Api()
+    {
+        // Arrange
+        string? capturedUrl = null;
+        var responseData = new SubscribersResponse
+        {
+            Subscribers = new[]
+            {
+                new Subscriber { Id = 1, EmailAddress = "cancelled@example.com", State = "cancelled" }
+            },
+            Pagination = new PaginationInfo { HasNextPage = false }
+        };
+
+        var json = JsonSerializer.Serialize(responseData, KitJsonContext.Default.SubscribersResponse);
+
+        _mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync((HttpRequestMessage request, CancellationToken _) =>
+            {
+                capturedUrl = request.RequestUri!.PathAndQuery;
+                return new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+            });
+
+        // Act
+        var result = await _client.GetSubscribersAsync(50, null, "cancelled");
+
+        // Assert
+        capturedUrl.Should().NotBeNull();
+        capturedUrl.Should().Contain("status=cancelled");
+        result.Data.Should().HaveCount(1);
+        result.Data[0].State.Should().Be("cancelled");
+    }
+
+    /// <summary>
+    /// Regression test for #113: GetAllSubscribersAsync should pass state to API.
+    /// </summary>
+    [Fact]
+    public async Task GetAllSubscribersAsync_Should_Pass_State_To_Api()
+    {
+        // Arrange
+        var capturedUrls = new List<string>();
+        var responseData = new SubscribersResponse
+        {
+            Subscribers = new[]
+            {
+                new Subscriber { Id = 1, EmailAddress = "cancelled@example.com", State = "cancelled" }
+            },
+            Pagination = new PaginationInfo { HasNextPage = false }
+        };
+
+        var json = JsonSerializer.Serialize(responseData, KitJsonContext.Default.SubscribersResponse);
+
+        _mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync((HttpRequestMessage request, CancellationToken _) =>
+            {
+                capturedUrls.Add(request.RequestUri!.PathAndQuery);
+                return new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+            });
+
+        // Act
+        var subscribers = new List<Subscriber>();
+        await foreach (var subscriber in _client.GetAllSubscribersAsync("cancelled"))
+        {
+            subscribers.Add(subscriber);
+        }
+
+        // Assert - verify the state was passed to the API
+        capturedUrls.Should().HaveCountGreaterThan(0);
+        capturedUrls[0].Should().Contain("status=cancelled");
+        subscribers.Should().HaveCount(1);
+    }
+
+    /// <summary>
+    /// Regression test for #112: Form cohort returns 0 subscribers.
+    /// GetFormSubscribersAsync must use SubscribersResponse type to properly parse the API response.
+    /// </summary>
+    [Fact]
+    public async Task GetFormSubscribersAsync_Should_Parse_Subscribers_Correctly()
+    {
+        // Arrange - Kit V4 API returns {"subscribers": [...], "pagination": {...}}
+        var responseData = new SubscribersResponse
+        {
+            Subscribers = new[]
+            {
+                new Subscriber { Id = 1, EmailAddress = "form1@example.com", State = "active" },
+                new Subscriber { Id = 2, EmailAddress = "form2@example.com", State = "active" },
+                new Subscriber { Id = 3, EmailAddress = "form3@example.com", State = "cancelled" }
+            },
+            Pagination = new PaginationInfo
+            {
+                HasNextPage = true,
+                EndCursor = "cursor123"
+            }
+        };
+
+        var json = JsonSerializer.Serialize(responseData, KitJsonContext.Default.SubscribersResponse);
+
+        _mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(json, Encoding.UTF8, "application/json")
+            });
+
+        // Act
+        var result = await _client.GetFormSubscribersAsync(12345, 50);
+
+        // Assert - this was returning 0 in #112 due to incorrect response type
+        result.Should().NotBeNull();
+        result.Data.Should().HaveCount(3);
+        result.Data[0].EmailAddress.Should().Be("form1@example.com");
+        result.Data[2].State.Should().Be("cancelled");
+        result.Pagination!.HasNextPage.Should().BeTrue();
+        result.Pagination.EndCursor.Should().Be("cursor123");
+    }
+
+    /// <summary>
+    /// Regression test for #112: Segment subscribers also needs correct response parsing.
+    /// </summary>
+    [Fact]
+    public async Task GetSegmentSubscribersAsync_Should_Parse_Subscribers_Correctly()
+    {
+        // Arrange - Kit V4 API returns {"subscribers": [...], "pagination": {...}}
+        var responseData = new SubscribersResponse
+        {
+            Subscribers = new[]
+            {
+                new Subscriber { Id = 1, EmailAddress = "seg1@example.com", State = "active" },
+                new Subscriber { Id = 2, EmailAddress = "seg2@example.com", State = "active" }
+            },
+            Pagination = new PaginationInfo
+            {
+                HasNextPage = false
+            }
+        };
+
+        var json = JsonSerializer.Serialize(responseData, KitJsonContext.Default.SubscribersResponse);
+
+        _mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(json, Encoding.UTF8, "application/json")
+            });
+
+        // Act
+        var result = await _client.GetSegmentSubscribersAsync(12345, 50);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Data.Should().HaveCount(2);
+        result.Data[0].EmailAddress.Should().Be("seg1@example.com");
+        result.Pagination!.HasNextPage.Should().BeFalse();
+    }
 }

--- a/src/KitCLI/Commands/SubscriberCommands.cs
+++ b/src/KitCLI/Commands/SubscriberCommands.cs
@@ -225,7 +225,7 @@ public static class SubscriberCommands
 
         string outputPath = "subscribers.csv";
         string? status = null;
-        bool allSubscribers = false;
+        int? limit = null; // null means all subscribers (default)
 
         for (int i = 0; i < args.Length; i++)
         {
@@ -247,8 +247,16 @@ public static class SubscriberCommands
                     }
 
                     break;
-                case "--all":
-                    allSubscribers = true;
+                case "--limit":
+                case "-l":
+                    if (i + 1 < args.Length && int.TryParse(args[++i], out var limitVal))
+                    {
+                        limit = limitVal;
+                    }
+
+                    break;
+                case "--all": // Keep for backwards compatibility, but it's now the default
+                    limit = null;
                     break;
             }
         }
@@ -268,27 +276,18 @@ public static class SubscriberCommands
 
         using var progress = new ProgressIndicator($"Exporting subscribers to {outputPath}");
 
-        List<Subscriber> subscribers;
+        List<Subscriber> subscribers = new List<Subscriber>();
+        int count = 0;
 
-        if (allSubscribers)
+        // Stream all subscribers (default) or up to limit
+        await foreach (var subscriber in client.GetAllSubscribersAsync(status))
         {
-            // Stream all subscribers
-            subscribers = new List<Subscriber>();
-            await foreach (var subscriber in client.GetAllSubscribersAsync(status))
-            {
-                subscribers.Add(subscriber);
-            }
-        }
-        else
-        {
-            // Just get first page
-            var response = await client.GetSubscribersAsync(100);
-            subscribers = response.Data.ToList();
+            subscribers.Add(subscriber);
+            count++;
 
-            if (!string.IsNullOrEmpty(status))
+            if (limit.HasValue && count >= limit.Value)
             {
-                subscribers = subscribers.Where(s =>
-                    s.State.Equals(status, StringComparison.OrdinalIgnoreCase)).ToList();
+                break;
             }
         }
 

--- a/src/KitCLI/KitJsonContext.cs
+++ b/src/KitCLI/KitJsonContext.cs
@@ -83,7 +83,7 @@ namespace KitCLI;
 [JsonSerializable(typeof(IncentiveEmail))]
 [JsonSerializable(typeof(ConfigFile))]
 [JsonSerializable(typeof(KitConfig))]
-[JsonSerializable(typeof(Dictionary<string, object>))]
+[JsonSerializable(typeof(Dictionary<string, JsonElement>))]
 [JsonSerializable(typeof(Dictionary<string, string>))]
 [JsonSerializable(typeof(ErrorResponse))]
 [JsonSerializable(typeof(GitHubRelease))]

--- a/src/KitCLI/Models/Subscriber.cs
+++ b/src/KitCLI/Models/Subscriber.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace KitCLI.Models;
@@ -20,7 +21,7 @@ public sealed class Subscriber
     public DateTime CreatedAt { get; set; }
 
     [JsonPropertyName("fields")]
-    public Dictionary<string, object>? Fields { get; set; }
+    public Dictionary<string, JsonElement>? Fields { get; set; }
 
     [JsonPropertyName("tags")]
     public Tag[]? Tags { get; set; }

--- a/src/KitCLI/Services/KitApiClient.cs
+++ b/src/KitCLI/Services/KitApiClient.cs
@@ -13,6 +13,7 @@ public interface IKitApiClient
     Task<PaginatedResponse<Subscriber>> GetSubscribersAsync(
         int perPage = 50,
         string? after = null,
+        string? state = null,
         CancellationToken cancellationToken = default);
 
     IAsyncEnumerable<Subscriber> GetAllSubscribersAsync(
@@ -172,12 +173,19 @@ public sealed class KitApiClient : IKitApiClient, IDisposable
     public async Task<PaginatedResponse<Subscriber>> GetSubscribersAsync(
         int perPage = 50,
         string? after = null,
+        string? state = null,
         CancellationToken cancellationToken = default)
     {
         var url = $"subscribers?per_page={perPage}";
         if (!string.IsNullOrEmpty(after))
         {
             url += $"&after={after}";
+        }
+
+        // Kit v4 API uses 'status' parameter to filter by subscriber state
+        if (!string.IsNullOrEmpty(state))
+        {
+            url += $"&status={state.ToLowerInvariant()}";
         }
 
         var response = await _httpClient.GetAsync(url, cancellationToken);
@@ -204,21 +212,18 @@ public sealed class KitApiClient : IKitApiClient, IDisposable
 
         while (hasMore && !cancellationToken.IsCancellationRequested)
         {
-            var page = await GetSubscribersAsync(100, cursor, cancellationToken);
+            // Pass state filter to API instead of filtering client-side
+            var page = await GetSubscribersAsync(100, cursor, state, cancellationToken);
 
             foreach (var subscriber in page.Data)
             {
-                // Filter by state if specified
-                if (state == null || subscriber.State.Equals(state, StringComparison.OrdinalIgnoreCase))
-                {
-                    yield return subscriber;
-                    totalProcessed++;
+                yield return subscriber;
+                totalProcessed++;
 
-                    // Report progress periodically
-                    if (totalProcessed % 100 == 0)
-                    {
-                        Console.Write($"\rProcessed {totalProcessed:N0} subscribers...");
-                    }
+                // Report progress periodically
+                if (totalProcessed % 100 == 0)
+                {
+                    Console.Write($"\rProcessed {totalProcessed:N0} subscribers...");
                 }
             }
 
@@ -471,8 +476,13 @@ public sealed class KitApiClient : IKitApiClient, IDisposable
 
         var json = await response.Content.ReadAsStringAsync(cancellationToken);
 
-        return JsonSerializer.Deserialize(json, KitJsonContext.Default.PaginatedResponseSubscriber)
-            ?? new PaginatedResponse<Subscriber>();
+        // Kit V4 API returns {"subscribers": [...], "pagination": {...}}
+        var result = JsonSerializer.Deserialize(json, KitJsonContext.Default.SubscribersResponse);
+        return new PaginatedResponse<Subscriber>
+        {
+            Data = result?.Subscribers ?? [],
+            Pagination = result?.Pagination
+        };
     }
 
     public async IAsyncEnumerable<Subscriber> GetAllSegmentSubscribersAsync(
@@ -836,8 +846,14 @@ public sealed class KitApiClient : IKitApiClient, IDisposable
         response.EnsureSuccessStatusCode();
 
         var json = await response.Content.ReadAsStringAsync(cancellationToken);
-        return JsonSerializer.Deserialize<PaginatedResponse<Subscriber>>(json, KitJsonContext.Default.PaginatedResponseSubscriber)
-               ?? new PaginatedResponse<Subscriber>();
+
+        // Kit V4 API returns {"subscribers": [...], "pagination": {...}}
+        var result = JsonSerializer.Deserialize(json, KitJsonContext.Default.SubscribersResponse);
+        return new PaginatedResponse<Subscriber>
+        {
+            Data = result?.Subscribers ?? [],
+            Pagination = result?.Pagination
+        };
     }
 
     public async IAsyncEnumerable<Subscriber> GetAllFormSubscribersAsync(


### PR DESCRIPTION
## Summary

Fixes four bugs reported against Kit CLI v1.2.0:

- **#115**: `subscriber list --format json` throws JsonTypeInfo serialization error
  - Root cause: `Dictionary<string, object>` cannot be serialized with AOT
  - Fix: Changed `Subscriber.Fields` to `Dictionary<string, JsonElement>`

- **#114**: Subscriber export only exports 100 subscribers
  - Root cause: Default behavior was to only export first page
  - Fix: Default now exports all subscribers; added `--limit` option to restrict

- **#113**: Cancelled subscriber list/export returns 0 results
  - Root cause: State filter was applied client-side after fetching all subscribers
  - Fix: Pass `status` parameter to Kit API to filter server-side

- **#112**: Form cohort analysis returns 0 subscribers for all forms
  - Root cause: `GetFormSubscribersAsync` was using wrong response type
  - Fix: Use `SubscribersResponse` type to match Kit V4 API format

Also fixed `GetSegmentSubscribersAsync` which had the same issue as #112.

## Test Plan

- [x] Added regression tests for JSON serialization with Fields property (#115)
- [x] Added test for state parameter being passed to API (#113)
- [x] Added tests for form and segment subscriber parsing (#112)
- [x] All 121 tests pass