### PR TITLE
feat: Add kit account stats command (#102)

### DIFF
--- a/src/KitCLI.Tests/Mocks/MockKitApiClient.cs
+++ b/src/KitCLI.Tests/Mocks/MockKitApiClient.cs
@@ -49,6 +49,9 @@ public sealed class MockKitApiClient : IKitApiClient
     public Func<long, int, CancellationToken, IAsyncEnumerable<Subscriber>>? GetAllFormSubscribersAsyncFunc { get; set; }
     public Func<long, string, CancellationToken, Task<bool>>? AddSubscriberToFormAsyncFunc { get; set; }
 
+    // Account
+    public Func<CancellationToken, Task<AccountStats?>>? GetAccountStatsAsyncFunc { get; set; }
+
     // Connection
     public Func<CancellationToken, Task<bool>>? TestConnectionAsyncFunc { get; set; }
 
@@ -62,6 +65,7 @@ public sealed class MockKitApiClient : IKitApiClient
     public List<Segment> Segments { get; set; } = new();
     public List<Sequence> Sequences { get; set; } = new();
     public List<Form> Forms { get; set; } = new();
+    public AccountStats? AccountStats { get; set; }
 
     // Subscribers
     public Task<PaginatedResponse<Subscriber>> GetSubscribersAsync(
@@ -428,6 +432,17 @@ public sealed class MockKitApiClient : IKitApiClient
         }
 
         return Task.FromResult(true);
+    }
+
+    // Account
+    public Task<AccountStats?> GetAccountStatsAsync(CancellationToken cancellationToken = default)
+    {
+        if (GetAccountStatsAsyncFunc != null)
+        {
+            return GetAccountStatsAsyncFunc(cancellationToken);
+        }
+
+        return Task.FromResult(AccountStats);
     }
 
     public Task<bool> TestConnectionAsync(CancellationToken cancellationToken = default)

--- a/src/KitCLI/Commands/AccountCommands.cs
+++ b/src/KitCLI/Commands/AccountCommands.cs
@@ -1,0 +1,101 @@
+using System.Text.Json;
+using KitCLI.Helpers;
+using KitCLI.Models;
+using KitCLI.Services;
+
+namespace KitCLI.Commands;
+
+/// <summary>
+/// Handles account-level commands.
+/// </summary>
+public static class AccountCommands
+{
+    /// <summary>
+    /// Handle the 'kit account stats' command.
+    /// Displays aggregate email statistics for the account.
+    /// </summary>
+    public static async Task<int> HandleStats(string[] args, IKitApiClient client)
+    {
+        if (CommandHelp.CheckForHelp(args))
+        {
+            return CommandHelp.ShowHelpAndReturn("account", "stats");
+        }
+
+        string format = "table";
+
+        for (int i = 0; i < args.Length; i++)
+        {
+            if ((args[i] == "--format" || args[i] == "-f") && i + 1 < args.Length)
+            {
+                format = args[++i].ToLowerInvariant();
+            }
+        }
+
+        using var progress = new ProgressIndicator("Fetching account statistics");
+
+        var stats = await client.GetAccountStatsAsync();
+
+        if (stats == null)
+        {
+            progress.Complete("Failed to fetch stats");
+            Console.WriteLine("Unable to retrieve account statistics. Please check your API key permissions.");
+            return 1;
+        }
+
+        progress.Complete("Retrieved account statistics");
+
+        PrintAccountStats(stats, format);
+        return 0;
+    }
+
+    private static void PrintAccountStats(AccountStats stats, string format)
+    {
+        switch (format.ToLowerInvariant())
+        {
+            case "json":
+                PrintAccountStatsJson(stats);
+                break;
+            case "csv":
+                PrintAccountStatsCsv(stats);
+                break;
+            default:
+                PrintAccountStatsTable(stats);
+                break;
+        }
+    }
+
+    private static void PrintAccountStatsTable(AccountStats stats)
+    {
+        var periodLabel = stats.EmailStatsMode switch
+        {
+            "last_90" => "Last 90 Days",
+            "last_30" => "Last 30 Days",
+            "last_7" => "Last 7 Days",
+            _ => stats.EmailStatsMode
+        };
+
+        Console.WriteLine();
+        Console.WriteLine($"Account Email Statistics ({periodLabel})");
+        Console.WriteLine(new string('─', 50));
+        Console.WriteLine($"Period:        {stats.Starting:yyyy-MM-dd} to {stats.Ending:yyyy-MM-dd}");
+        Console.WriteLine($"Sent:          {stats.Sent:N0}");
+        Console.WriteLine($"Opened:        {stats.Opened:N0} ({stats.OpenRate:F1}%)");
+        Console.WriteLine($"Clicked:       {stats.Clicked:N0} ({stats.ClickRate:F1}%)");
+        Console.WriteLine();
+        Console.WriteLine("Tracking:");
+        Console.WriteLine($"  Open tracking:  {(stats.OpenTrackingEnabled ? "Enabled" : "Disabled")}");
+        Console.WriteLine($"  Click tracking: {(stats.ClickTrackingEnabled ? "Enabled" : "Disabled")}");
+    }
+
+    private static void PrintAccountStatsJson(AccountStats stats)
+    {
+        var json = JsonSerializer.Serialize(stats, KitJsonIndentedContext.Default.AccountStats);
+        Console.WriteLine(json);
+    }
+
+    private static void PrintAccountStatsCsv(AccountStats stats)
+    {
+        Console.WriteLine("starting,ending,sent,opened,clicked,open_rate,click_rate,open_tracking,click_tracking");
+        Console.WriteLine($"{stats.Starting:yyyy-MM-dd},{stats.Ending:yyyy-MM-dd},{stats.Sent},{stats.Opened},{stats.Clicked},{stats.OpenRate:F2},{stats.ClickRate:F2},{stats.OpenTrackingEnabled},{stats.ClickTrackingEnabled}");
+    }
+}

--- a/src/KitCLI/Helpers/CommandHelp.cs
+++ b/src/KitCLI/Helpers/CommandHelp.cs
@@ -22,7 +22,8 @@ public static class CommandHelp
                 ["webhook"] = "Manage webhooks",
                 ["purchase"] = "Manage purchase data",
                 ["export"] = "Export data to various formats",
-                ["cohort"] = "Analyze subscriber cohorts over time"
+                ["cohort"] = "Analyze subscriber cohorts over time",
+                ["account"] = "View account-level statistics"
             },
             Options = new Dictionary<string, string>
             {
@@ -676,6 +677,30 @@ public static class CommandHelp
                 "kit cohort by-form --form-ids 12345,67890 --compare",
                 "kit cohort by-form --days 180 --format json",
                 "kit cohort by-form --include-archived --export form-cohorts.csv"
+            }
+        },
+        ["account"] = new CommandHelpInfo
+        {
+            Usage = "kit account <subcommand> [options]",
+            Description = "View account-level statistics and metrics",
+            Subcommands = new Dictionary<string, string>
+            {
+                ["stats"] = "Show aggregate email statistics for the account"
+            }
+        },
+        ["account stats"] = new CommandHelpInfo
+        {
+            Usage = "kit account stats [options]",
+            Description = "Display aggregate email statistics for the account, including total sent, opened, and clicked counts with engagement rates.",
+            Options = new Dictionary<string, string>
+            {
+                ["--format, -f <format>"] = "Output format: table (default), json, csv"
+            },
+            Examples = new[]
+            {
+                "kit account stats",
+                "kit account stats --format json",
+                "kit account stats -f csv"
             }
         }
     };

--- a/src/KitCLI/KitJsonContext.cs
+++ b/src/KitCLI/KitJsonContext.cs
@@ -11,6 +11,8 @@ namespace KitCLI;
     PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     Converters = [typeof(DateTimeOffsetConverter)])]
+[JsonSerializable(typeof(AccountStats))]
+[JsonSerializable(typeof(AccountStatsResponse))]
 [JsonSerializable(typeof(Subscriber))]
 [JsonSerializable(typeof(Subscriber[]))]
 [JsonSerializable(typeof(List<Subscriber>))]
@@ -124,6 +126,7 @@ public partial class KitJsonContext : JsonSerializerContext
     WriteIndented = true,
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(AccountStats))]
 [JsonSerializable(typeof(Subscriber))]
 [JsonSerializable(typeof(Subscriber[]))]
 [JsonSerializable(typeof(Broadcast))]

--- a/src/KitCLI/Models/AccountStats.cs
+++ b/src/KitCLI/Models/AccountStats.cs
@@ -1,0 +1,48 @@
+using System.Text.Json.Serialization;
+
+namespace KitCLI.Models;
+
+/// <summary>
+/// Account-level email statistics from the Kit API.
+/// </summary>
+public sealed class AccountStats
+{
+    [JsonPropertyName("sent")]
+    public int Sent { get; set; }
+
+    [JsonPropertyName("clicked")]
+    public int Clicked { get; set; }
+
+    [JsonPropertyName("opened")]
+    public int Opened { get; set; }
+
+    [JsonPropertyName("email_stats_mode")]
+    public string EmailStatsMode { get; set; } = "last_90";
+
+    [JsonPropertyName("open_tracking_enabled")]
+    public bool OpenTrackingEnabled { get; set; }
+
+    [JsonPropertyName("click_tracking_enabled")]
+    public bool ClickTrackingEnabled { get; set; }
+
+    [JsonPropertyName("starting")]
+    public DateTime Starting { get; set; }
+
+    [JsonPropertyName("ending")]
+    public DateTime Ending { get; set; }
+
+    [JsonIgnore]
+    public double OpenRate => Sent > 0 ? (double)Opened / Sent * 100 : 0;
+
+    [JsonIgnore]
+    public double ClickRate => Sent > 0 ? (double)Clicked / Sent * 100 : 0;
+}
+
+/// <summary>
+/// Response wrapper for account email stats endpoint.
+/// </summary>
+public sealed class AccountStatsResponse
+{
+    [JsonPropertyName("stats")]
+    public AccountStats? Stats { get; set; }
+}

--- a/src/KitCLI/Program.cs
+++ b/src/KitCLI/Program.cs
@@ -136,6 +136,7 @@ static async Task<int> RouteCommand(string[] args, bool isReadOnly = false, bool
         "sequence" => await HandleSequenceCommand(args[1..], isReadOnly),
         "form" => await HandleFormCommand(args[1..], isReadOnly),
         "cohort" => await HandleCohortCommand(args[1..], isReadOnly),
+        "account" => await HandleAccountCommand(args[1..], isReadOnly),
         "update" => await UpdateCommand.HandleUpdate(args[1..], currentVersion ?? "0.1.0"),
         "export" => await HandleExportCommand(args[1..], isReadOnly),
         _ => ShowUnknownCommand(args[0])
@@ -849,6 +850,50 @@ static async Task<int> HandleCohortCommand(string[] args, bool isReadOnly)
         "by-tag" => await CohortCommands.HandleByTag(args[1..], client),
         "by-form" => await CohortCommands.HandleByForm(args[1..], client),
         _ => ShowUnknownCommand($"cohort {args[0]}")
+    };
+}
+
+static async Task<int> HandleAccountCommand(string[] args, bool isReadOnly)
+{
+    if (args.Length < 1)
+    {
+        return CommandHelp.ShowHelpAndReturn("account");
+    }
+
+    // Check if help is requested for the account command itself
+    if (args.Length == 1 && CommandHelp.CheckForHelp(args))
+    {
+        return CommandHelp.ShowHelpAndReturn("account");
+    }
+
+    // Check if help is requested for a subcommand (before loading config)
+    if (args.Length >= 2 && CommandHelp.CheckForHelp(args[1..]))
+    {
+        return CommandHelp.ShowHelpAndReturn("account", args[0].ToLowerInvariant());
+    }
+
+    var profile = ExtractProfileFromArgs(ref args);
+    var configService = new ConfigurationService();
+    var configFile = await configService.LoadConfigFileAsync();
+    var effectiveProfile = profile ?? configFile.CurrentProfile ?? "default";
+    var config = await configService.LoadConfigAsync(profile);
+
+    if (config == null || !config.IsValid)
+    {
+        Console.WriteLine($"Invalid or missing configuration for profile '{effectiveProfile}'. Use 'kit config set --profile {effectiveProfile}' to configure.");
+        return 1;
+    }
+
+    // Display profile info
+    var isVerbose = Environment.GetEnvironmentVariable("KIT_CLI_VERBOSE") == "1";
+    DisplayProfileInfo(effectiveProfile, configFile.CurrentProfile, isVerbose);
+
+    using var client = new KitApiClient(config);
+
+    return args[0].ToLowerInvariant() switch
+    {
+        "stats" => await AccountCommands.HandleStats(args[1..], client),
+        _ => ShowUnknownCommand($"account {args[0]}")
     };
 }
 

--- a/src/KitCLI/Services/KitApiClient.cs
+++ b/src/KitCLI/Services/KitApiClient.cs
@@ -113,6 +113,9 @@ public interface IKitApiClient
 
     Task<bool> AddSubscriberToFormAsync(long formId, string email, CancellationToken cancellationToken = default);
 
+    // Account
+    Task<AccountStats?> GetAccountStatsAsync(CancellationToken cancellationToken = default);
+
     // Test connection
     Task<bool> TestConnectionAsync(CancellationToken cancellationToken = default);
 }
@@ -896,6 +899,21 @@ public sealed class KitApiClient : IKitApiClient, IDisposable
         {
             return false;
         }
+    }
+
+    // Account
+    public async Task<AccountStats?> GetAccountStatsAsync(CancellationToken cancellationToken = default)
+    {
+        var response = await _httpClient.GetAsync("account/email_stats", cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return null;
+        }
+
+        var json = await response.Content.ReadAsStringAsync(cancellationToken);
+        var result = JsonSerializer.Deserialize(json, KitJsonContext.Default.AccountStatsResponse);
+        return result?.Stats;
     }
 
     public async Task<bool> TestConnectionAsync(CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary
- Adds `kit account stats` command to display aggregate email statistics for the Kit account
- Shows sent, opened, clicked counts with engagement rates (open rate, click rate)
- Supports table (default), JSON, and CSV output formats
- Includes tracking status (open tracking, click tracking enabled/disabled)

## Changes
- Created `AccountStats` model and `AccountStatsResponse` wrapper class
- Added `GetAccountStatsAsync` to `IKitApiClient` interface and implementation
- Created `AccountCommands.HandleStats` command handler
- Added routing and help text

## Test plan
- [x] Build passes with no warnings
- [x] All existing tests pass
- [ ] Manual testing: `kit account stats`
- [ ] Manual testing: `kit account stats --format json`
- [ ] Manual testing: `kit account stats --format csv`

Closes #102