### PR TITLE
feat: Add kit subscribers cold command for finding disengaged subscribers (#64)

### DIFF
--- a/src/KitCLI/Commands/SubscriberCommands.cs
+++ b/src/KitCLI/Commands/SubscriberCommands.cs
@@ -693,6 +693,363 @@ public static class SubscriberCommands
         Console.WriteLine($"Exported scores to {path}");
     }
 
+    public static async Task<int> HandleCold(string[] args, IKitApiClient client)
+    {
+        if (CommandHelp.CheckForHelp(args))
+        {
+            return CommandHelp.ShowHelpAndReturn("subscribers", "cold");
+        }
+
+        int minDaysOld = 90;
+        int maxTags = 2;
+        bool wasActiveFilter = false;
+        int limit = 100;
+        string format = "table";
+        string? exportPath = null;
+
+        for (int i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--min-days-old":
+                case "--no-opens-days":
+                case "-d":
+                    if (i + 1 < args.Length && int.TryParse(args[++i], out var days))
+                    {
+                        minDaysOld = days;
+                    }
+                    break;
+                case "--max-tags":
+                case "-t":
+                    if (i + 1 < args.Length && int.TryParse(args[++i], out var tags))
+                    {
+                        maxTags = tags;
+                    }
+                    break;
+                case "--was-active":
+                    wasActiveFilter = true;
+                    break;
+                case "--limit":
+                case "-l":
+                    if (i + 1 < args.Length && int.TryParse(args[++i], out var l))
+                    {
+                        limit = l;
+                    }
+                    break;
+                case "--format":
+                case "-f":
+                    if (i + 1 < args.Length)
+                    {
+                        format = args[++i].ToLowerInvariant();
+                    }
+                    break;
+                case "--export":
+                case "-e":
+                    if (i + 1 < args.Length)
+                    {
+                        exportPath = args[++i];
+                    }
+                    break;
+            }
+        }
+
+        using var progress = new ProgressIndicator("Analyzing subscribers for cold contacts");
+
+        // Get all active subscribers
+        var allSubscribers = new List<Subscriber>();
+        await foreach (var subscriber in client.GetAllSubscribersAsync("active"))
+        {
+            allSubscribers.Add(subscriber);
+        }
+
+        progress.Dispose();
+        Console.WriteLine();
+
+        if (allSubscribers.Count == 0)
+        {
+            Console.WriteLine("No subscribers found.");
+            return 0;
+        }
+
+        // Fetch tags for each subscriber
+        Console.Write("Fetching subscriber tags...");
+        var subscriberTagCounts = new Dictionary<long, (int count, string tagNames)>();
+        var batchSize = 10;
+        var batches = allSubscribers.Chunk(batchSize);
+        var processed = 0;
+
+        foreach (var batch in batches)
+        {
+            var tagTasks = batch.Select(async s =>
+            {
+                try
+                {
+                    var tags = await client.GetSubscriberTagsAsync(s.Id);
+                    return (s.Id, Count: tags.Length, Names: string.Join(", ", tags.Select(t => t.Name)));
+                }
+                catch
+                {
+                    return (s.Id, Count: s.Tags?.Length ?? 0, Names: s.TagList);
+                }
+            });
+
+            var results = await Task.WhenAll(tagTasks);
+            foreach (var (id, count, names) in results)
+            {
+                subscriberTagCounts[id] = (count, names);
+            }
+
+            processed += batch.Length;
+            Console.Write($"\rFetching subscriber tags... {processed:N0}/{allSubscribers.Count:N0}");
+        }
+
+        Console.WriteLine($"\rFetching subscriber tags... Done ({processed:N0} subscribers)");
+
+        // Filter for cold subscribers
+        var now = DateTime.UtcNow;
+        var coldSubscribers = new List<ColdSubscriber>();
+        var tierBreakdown = new ColdTierBreakdown();
+
+        foreach (var subscriber in allSubscribers)
+        {
+            var accountAgeDays = (int)(now - subscriber.CreatedAt).TotalDays;
+            var (tagCount, tagNames) = subscriberTagCounts.GetValueOrDefault(subscriber.Id, (0, ""));
+
+            // Skip if account is too new
+            if (accountAgeDays < minDaysOld)
+            {
+                continue;
+            }
+
+            // Determine engagement tier based on tag count
+            string engagementTier;
+            if (tagCount == 0)
+            {
+                engagementTier = "none";
+            }
+            else if (tagCount <= 2)
+            {
+                engagementTier = "low";
+            }
+            else if (tagCount <= 5)
+            {
+                engagementTier = "medium";
+            }
+            else
+            {
+                engagementTier = "high";
+            }
+
+            // Check if subscriber is "cold" (low tag count for their age)
+            bool isCold = tagCount <= maxTags;
+
+            // If was-active filter, only include those with at least 1 tag
+            if (wasActiveFilter && tagCount == 0)
+            {
+                continue;
+            }
+
+            if (isCold)
+            {
+                var coldReason = tagCount == 0
+                    ? $"No tags after {accountAgeDays} days"
+                    : $"Only {tagCount} tag(s) after {accountAgeDays} days";
+
+                coldSubscribers.Add(new ColdSubscriber
+                {
+                    Id = subscriber.Id,
+                    Email = subscriber.EmailAddress,
+                    FirstName = subscriber.FirstName,
+                    State = subscriber.State,
+                    CreatedAt = subscriber.CreatedAt,
+                    AccountAgeDays = accountAgeDays,
+                    TagCount = tagCount,
+                    Tags = tagNames,
+                    EngagementTier = engagementTier,
+                    ColdReason = coldReason
+                });
+
+                // Update tier breakdown
+                switch (engagementTier)
+                {
+                    case "none":
+                        tierBreakdown.NeverEngaged++;
+                        break;
+                    case "low":
+                        tierBreakdown.PreviouslyLow++;
+                        break;
+                    case "medium":
+                        tierBreakdown.PreviouslyMedium++;
+                        break;
+                    case "high":
+                        tierBreakdown.PreviouslyHigh++;
+                        break;
+                }
+            }
+        }
+
+        // Sort by account age descending (oldest first)
+        coldSubscribers = coldSubscribers
+            .OrderByDescending(s => s.AccountAgeDays)
+            .Take(limit)
+            .ToList();
+
+        var coldPercentage = allSubscribers.Count > 0
+            ? (double)coldSubscribers.Count / allSubscribers.Count * 100
+            : 0;
+
+        var result = new ColdSubscribersResult
+        {
+            MinDaysOld = minDaysOld,
+            MaxTags = maxTags,
+            WasActiveFilter = wasActiveFilter,
+            TotalAnalyzed = allSubscribers.Count,
+            ColdCount = coldSubscribers.Count,
+            ColdPercentage = Math.Round(coldPercentage, 1),
+            Subscribers = coldSubscribers.ToArray(),
+            TierBreakdown = tierBreakdown,
+            Note = "Cold subscribers are identified by low tag counts relative to account age. " +
+                   "Kit v4 API does not provide per-subscriber engagement metrics (opens, clicks)."
+        };
+
+        // Output
+        if (format == "json")
+        {
+            var json = System.Text.Json.JsonSerializer.Serialize(result,
+                KitJsonIndentedContext.Default.ColdSubscribersResult);
+            Console.WriteLine(json);
+        }
+        else if (format == "csv")
+        {
+            PrintColdCsv(result);
+        }
+        else
+        {
+            PrintColdTable(result);
+        }
+
+        // Export if requested
+        if (!string.IsNullOrEmpty(exportPath))
+        {
+            await ExportCold(result, exportPath);
+        }
+
+        return 0;
+    }
+
+    private static void PrintColdTable(ColdSubscribersResult result)
+    {
+        Console.WriteLine();
+        Console.WriteLine($"Cold Subscribers Analysis");
+        Console.WriteLine(new string('=', 80));
+        Console.WriteLine($"Criteria: Account age >= {result.MinDaysOld} days, Tag count <= {result.MaxTags}");
+        if (result.WasActiveFilter)
+        {
+            Console.WriteLine("Filter: Only previously engaged (had at least 1 tag)");
+        }
+        Console.WriteLine($"Total analyzed: {result.TotalAnalyzed:N0}");
+        Console.WriteLine($"Cold subscribers: {result.ColdCount:N0} ({result.ColdPercentage:F1}%)");
+        Console.WriteLine();
+
+        if (result.TierBreakdown != null)
+        {
+            Console.WriteLine("Engagement Tier Breakdown:");
+            Console.WriteLine($"  Never engaged (0 tags):     {result.TierBreakdown.NeverEngaged:N0}");
+            Console.WriteLine($"  Previously low (1-2 tags):  {result.TierBreakdown.PreviouslyLow:N0}");
+            Console.WriteLine($"  Previously medium (3-5):    {result.TierBreakdown.PreviouslyMedium:N0}");
+            Console.WriteLine($"  Previously high (6+):       {result.TierBreakdown.PreviouslyHigh:N0}");
+            Console.WriteLine();
+        }
+
+        Console.WriteLine("Note: " + result.Note);
+        Console.WriteLine();
+
+        if (result.Subscribers.Length == 0)
+        {
+            Console.WriteLine("No cold subscribers found matching criteria.");
+            return;
+        }
+
+        // Header
+        Console.WriteLine($"{"Email",-35} {"Age",-6} {"Tags",-5} {"Tier",-8} {"Reason",-20}");
+        Console.WriteLine(new string('-', 80));
+
+        foreach (var subscriber in result.Subscribers)
+        {
+            var email = subscriber.Email.Length > 33
+                ? subscriber.Email[..30] + "..."
+                : subscriber.Email;
+
+            var ageStr = subscriber.AccountAgeDays > 365
+                ? $"{subscriber.AccountAgeDays / 365}y"
+                : $"{subscriber.AccountAgeDays}d";
+
+            var reason = subscriber.ColdReason.Length > 18
+                ? subscriber.ColdReason[..15] + "..."
+                : subscriber.ColdReason;
+
+            Console.WriteLine($"{email,-35} {ageStr,-6} {subscriber.TagCount,-5} {subscriber.EngagementTier,-8} {reason,-20}");
+        }
+
+        Console.WriteLine();
+        Console.WriteLine($"Showing {result.Subscribers.Length} of {result.ColdCount:N0} cold subscribers");
+    }
+
+    private static void PrintColdCsv(ColdSubscribersResult result)
+    {
+        Console.WriteLine("id,email,first_name,state,created_at,account_age_days,tag_count,tags,engagement_tier,cold_reason");
+
+        foreach (var subscriber in result.Subscribers)
+        {
+            var email = EscapeCsvField(subscriber.Email);
+            var name = EscapeCsvField(subscriber.FirstName ?? "");
+            var tags = EscapeCsvField(subscriber.Tags);
+            var reason = EscapeCsvField(subscriber.ColdReason);
+
+            Console.WriteLine($"{subscriber.Id},{email},{name},{subscriber.State},{subscriber.CreatedAt:yyyy-MM-dd},{subscriber.AccountAgeDays},{subscriber.TagCount},{tags},{subscriber.EngagementTier},{reason}");
+        }
+    }
+
+    private static async Task ExportCold(ColdSubscribersResult result, string path)
+    {
+        var format = Path.GetExtension(path).ToLowerInvariant() switch
+        {
+            ".json" => "json",
+            ".csv" => "csv",
+            _ => "csv"
+        };
+
+        if (!path.Contains('.'))
+        {
+            path += ".csv";
+        }
+
+        using var writer = new StreamWriter(path);
+
+        if (format == "json")
+        {
+            var json = System.Text.Json.JsonSerializer.Serialize(result,
+                KitJsonIndentedContext.Default.ColdSubscribersResult);
+            await writer.WriteAsync(json);
+        }
+        else
+        {
+            await writer.WriteLineAsync("id,email,first_name,state,created_at,account_age_days,tag_count,tags,engagement_tier,cold_reason");
+
+            foreach (var subscriber in result.Subscribers)
+            {
+                var email = EscapeCsvField(subscriber.Email);
+                var name = EscapeCsvField(subscriber.FirstName ?? "");
+                var tags = EscapeCsvField(subscriber.Tags);
+                var reason = EscapeCsvField(subscriber.ColdReason);
+
+                await writer.WriteLineAsync($"{subscriber.Id},{email},{name},{subscriber.State},{subscriber.CreatedAt:yyyy-MM-dd},{subscriber.AccountAgeDays},{subscriber.TagCount},{tags},{subscriber.EngagementTier},{reason}");
+            }
+        }
+
+        Console.WriteLine($"Exported cold subscribers to {path}");
+    }
+
     private static string EscapeCsvField(string field)
     {
         if (string.IsNullOrEmpty(field))

--- a/src/KitCLI/Helpers/CommandHelp.cs
+++ b/src/KitCLI/Helpers/CommandHelp.cs
@@ -286,7 +286,8 @@ public static class CommandHelp
             {
                 ["date-range"] = "Find subscribers by date range",
                 ["inactive"] = "Find inactive subscribers",
-                ["unsubscribed"] = "Find unsubscribed users"
+                ["unsubscribed"] = "Find unsubscribed users",
+                ["cold"] = "Find cold (disengaged) subscribers"
             }
         },
         ["subscribers date-range"] = new CommandHelpInfo
@@ -338,6 +339,28 @@ public static class CommandHelp
             {
                 "kit subscribers unsubscribed",
                 "kit subscribers unsubscribed --since 2024-01-01 --format csv -o unsubs.csv"
+            }
+        },
+        ["subscribers cold"] = new CommandHelpInfo
+        {
+            Usage = "kit subscribers cold [options]",
+            Description = "Find cold (disengaged) subscribers based on account age and tag count. Note: Kit v4 API does not provide per-subscriber engagement metrics (opens, clicks), so cold detection uses proxy signals.",
+            Options = new Dictionary<string, string>
+            {
+                ["--min-days-old, -d <days>"] = "Minimum account age for 'cold' classification (default: 90)",
+                ["--max-tags, -t <count>"] = "Maximum tag count threshold for 'cold' (default: 2)",
+                ["--was-active"] = "Only include subscribers who had some engagement (at least 1 tag)",
+                ["--limit, -l <number>"] = "Maximum subscribers to return (default: 100)",
+                ["--format, -f <format>"] = "Output format: table (default), json, csv",
+                ["--export, -e <path>"] = "Export to file (CSV or JSON based on extension)"
+            },
+            Examples = new[]
+            {
+                "kit subscribers cold",
+                "kit subscribers cold --min-days-old 180",
+                "kit subscribers cold --max-tags 1 --was-active",
+                "kit subscribers cold --format json",
+                "kit subscribers cold --export cold-subscribers.csv"
             }
         },
         ["campaign"] = new CommandHelpInfo

--- a/src/KitCLI/KitJsonContext.cs
+++ b/src/KitCLI/KitJsonContext.cs
@@ -124,6 +124,10 @@ namespace KitCLI;
 [JsonSerializable(typeof(ScoredSubscriber[]))]
 [JsonSerializable(typeof(ScoreBreakdown))]
 [JsonSerializable(typeof(SubscriberScoresResult))]
+[JsonSerializable(typeof(ColdSubscriber))]
+[JsonSerializable(typeof(ColdSubscriber[]))]
+[JsonSerializable(typeof(ColdSubscribersResult))]
+[JsonSerializable(typeof(ColdTierBreakdown))]
 public partial class KitJsonContext : JsonSerializerContext
 {
 }
@@ -194,6 +198,10 @@ public partial class KitJsonContext : JsonSerializerContext
 [JsonSerializable(typeof(ScoredSubscriber[]))]
 [JsonSerializable(typeof(ScoreBreakdown))]
 [JsonSerializable(typeof(SubscriberScoresResult))]
+[JsonSerializable(typeof(ColdSubscriber))]
+[JsonSerializable(typeof(ColdSubscriber[]))]
+[JsonSerializable(typeof(ColdSubscribersResult))]
+[JsonSerializable(typeof(ColdTierBreakdown))]
 public partial class KitJsonIndentedContext : JsonSerializerContext
 {
 }

--- a/src/KitCLI/Models/CohortAnalysis.cs
+++ b/src/KitCLI/Models/CohortAnalysis.cs
@@ -699,3 +699,146 @@ public sealed class SubscriberScoresResult
     [JsonPropertyName("note")]
     public string Note { get; set; } = string.Empty;
 }
+
+/// <summary>
+/// A subscriber identified as "cold" (disengaged) based on available signals.
+/// Note: Kit v4 API does not provide per-subscriber engagement metrics,
+/// so "cold" is inferred from account age, tag count, and state.
+/// </summary>
+public sealed class ColdSubscriber
+{
+    [JsonPropertyName("id")]
+    public long Id { get; set; }
+
+    [JsonPropertyName("email")]
+    public string Email { get; set; } = string.Empty;
+
+    [JsonPropertyName("first_name")]
+    public string? FirstName { get; set; }
+
+    [JsonPropertyName("state")]
+    public string State { get; set; } = string.Empty;
+
+    [JsonPropertyName("created_at")]
+    public DateTime CreatedAt { get; set; }
+
+    /// <summary>
+    /// Age of subscriber account in days
+    /// </summary>
+    [JsonPropertyName("account_age_days")]
+    public int AccountAgeDays { get; set; }
+
+    /// <summary>
+    /// Number of tags associated with this subscriber
+    /// </summary>
+    [JsonPropertyName("tag_count")]
+    public int TagCount { get; set; }
+
+    /// <summary>
+    /// Comma-separated list of tag names
+    /// </summary>
+    [JsonPropertyName("tags")]
+    public string Tags { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Engagement tier based on tag count: none, low, medium
+    /// </summary>
+    [JsonPropertyName("engagement_tier")]
+    public string EngagementTier { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Reason subscriber was flagged as cold
+    /// </summary>
+    [JsonPropertyName("cold_reason")]
+    public string ColdReason { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Complete result of cold subscriber analysis.
+/// </summary>
+public sealed class ColdSubscribersResult
+{
+    /// <summary>
+    /// Minimum account age in days for "cold" classification
+    /// </summary>
+    [JsonPropertyName("min_days_old")]
+    public int MinDaysOld { get; set; }
+
+    /// <summary>
+    /// Maximum tag count threshold for "cold" classification
+    /// </summary>
+    [JsonPropertyName("max_tags")]
+    public int MaxTags { get; set; }
+
+    /// <summary>
+    /// Whether filtering to "was-active" (had some engagement before)
+    /// </summary>
+    [JsonPropertyName("was_active_filter")]
+    public bool WasActiveFilter { get; set; }
+
+    /// <summary>
+    /// Total subscribers analyzed
+    /// </summary>
+    [JsonPropertyName("total_analyzed")]
+    public int TotalAnalyzed { get; set; }
+
+    /// <summary>
+    /// Number of cold subscribers found
+    /// </summary>
+    [JsonPropertyName("cold_count")]
+    public int ColdCount { get; set; }
+
+    /// <summary>
+    /// Percentage of subscribers that are cold
+    /// </summary>
+    [JsonPropertyName("cold_percentage")]
+    public double ColdPercentage { get; set; }
+
+    /// <summary>
+    /// The cold subscribers
+    /// </summary>
+    [JsonPropertyName("subscribers")]
+    public ColdSubscriber[] Subscribers { get; set; } = [];
+
+    /// <summary>
+    /// Breakdown by engagement tier
+    /// </summary>
+    [JsonPropertyName("tier_breakdown")]
+    public ColdTierBreakdown? TierBreakdown { get; set; }
+
+    /// <summary>
+    /// Note about API limitations
+    /// </summary>
+    [JsonPropertyName("note")]
+    public string Note { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Breakdown of cold subscribers by their previous engagement tier.
+/// </summary>
+public sealed class ColdTierBreakdown
+{
+    /// <summary>
+    /// Count of cold subscribers with zero engagement (no tags ever)
+    /// </summary>
+    [JsonPropertyName("never_engaged")]
+    public int NeverEngaged { get; set; }
+
+    /// <summary>
+    /// Count of cold subscribers with low previous engagement (1-2 tags)
+    /// </summary>
+    [JsonPropertyName("previously_low")]
+    public int PreviouslyLow { get; set; }
+
+    /// <summary>
+    /// Count of cold subscribers with medium previous engagement (3-5 tags)
+    /// </summary>
+    [JsonPropertyName("previously_medium")]
+    public int PreviouslyMedium { get; set; }
+
+    /// <summary>
+    /// Count of cold subscribers with high previous engagement (6+ tags but still cold)
+    /// </summary>
+    [JsonPropertyName("previously_high")]
+    public int PreviouslyHigh { get; set; }
+}

--- a/src/KitCLI/Program.cs
+++ b/src/KitCLI/Program.cs
@@ -599,6 +599,7 @@ static async Task<int> HandleSubscribersCommand(string[] args, bool isReadOnly)
         "date-range" => await AdvancedFilteringCommands.HandleSubscribersByDateRange(args[1..], client),
         "inactive" => await AdvancedFilteringCommands.HandleInactiveSubscribers(args[1..], client),
         "unsubscribed" => await AdvancedFilteringCommands.HandleBulkUnsubscribed(args[1..], client),
+        "cold" => await SubscriberCommands.HandleCold(args[1..], client),
         _ => ShowUnknownCommand($"subscribers {args[0]}")
     };
 }


### PR DESCRIPTION
## Summary
- Implements #64: `kit subscribers cold` command to find "cold" (disengaged) subscribers
- Uses proxy signals (account age + tag count) since Kit v4 API doesn't provide per-subscriber engagement metrics
- Configurable thresholds for minimum account age and maximum tag count
- Includes engagement tier breakdown and export capabilities

## Features
- `--min-days-old` / `-d` - Minimum account age for cold classification (default: 90 days)
- `--max-tags` / `-t` - Maximum tag count threshold (default: 2)
- `--was-active` - Filter to only previously-engaged subscribers (had at least 1 tag)
- `--format` - Output as table (default), json, or csv
- `--export` - Export to file

## Test plan
- [x] Builds successfully
- [x] All tests pass
- [ ] CI pipeline passes