### PR TITLE
chore: Prepare release v1.3.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,28 +8,41 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>1.2.0</VersionPrefix>
+    <VersionPrefix>1.3.0</VersionPrefix>
     <PackageReleaseNotes>**New Features:**
-- **Cohort Analysis**: Added suite of cohort analysis commands for retention and lead source tracking
-  - `kit cohort by-signup` - Retention analysis by signup date (#94)
-  - `kit cohort by-tag` - Tag-based cohort analysis (#96)
-  - `kit cohort by-form` - Lead source analysis by form (#99)
-  - Shows subscriber retention over time with configurable periods (daily, weekly, monthly)
+- **Account Analytics**: Added `kit account stats` command for aggregate email statistics (#117, #102)
+  - View total sent, opened, and clicked counts
+  - Display engagement rates (open rate, click rate)
+  - Shows tracking status (open/click tracking enabled)
+  - Supports table, JSON, and CSV output formats
 
-- **Broadcast Analytics**: Enhanced broadcast performance tracking and comparison
-  - `kit broadcast trends` - Performance trend analysis over time (#106)
-  - `kit broadcast compare` - Side-by-side comparison of multiple broadcasts (#109, #59)
-  - Identify best-performing broadcasts and content patterns
+- **Top Broadcast Analysis**: Added `kit broadcast top` command to identify best-performing broadcasts (#118, #61)
+  - Rank broadcasts by metric: opens, clicks, or engagement score
+  - Engagement scoring: `(OpenRate * 0.6) + (ClickRate * 0.4)`
+  - Configurable time range with `--days` (default: 30)
+  - Limit results with `--limit` (default: 10)
+  - Export capabilities with progress indicators
 
-- **Form Analytics**: New form performance tracking capabilities
-  - `kit form trends` - Signup trend analysis for forms (#110)
-  - `kit form compare` - Compare performance across multiple forms (#108)
-  - Track conversion rates and signup patterns over time
+- **Subscriber Engagement Scoring**: Added `kit subscriber scores` command for calculating engagement scores (#119, #63)
+  - Multiple scoring algorithms: weighted (default), tags, maturity
+  - Weighted algorithm balances tag engagement (50 pts), account maturity (30 pts), and active status (20 pts)
+  - Tags algorithm: pure tag-based scoring (10 points per tag, max 100)
+  - Maturity algorithm: account age focused (80 points at 365+ days + 20 for active)
+  - Filter by segment and customize result limits
+  - Export with multiple output formats
+
+- **Cold Subscriber Detection**: Added `kit subscribers cold` command to find disengaged subscribers (#120, #64)
+  - Uses proxy signals: account age + tag count to identify cold subscribers
+  - Configurable thresholds: `--min-days-old` (default: 90) and `--max-tags` (default: 2)
+  - `--was-active` filter for previously-engaged subscribers
+  - Engagement tier breakdown and export capabilities
+  - Helps identify subscribers for re-engagement campaigns or list cleanup
 
 **Bug Fixes:**
-- **Sequence Display**: Removed misleading subscriber/email columns from sequence list when Kit API v4 doesn't provide data (#104)
-- **Segment Subscriber Display**: Fixed segment subscriber count display to accurately reflect Kit API v4 data (#96)
-- **API Compatibility**: Added proper handling for missing Kit API v4 sequence endpoints to prevent errors (#103)</PackageReleaseNotes>
+- **JSON Serialization**: Fixed `subscriber list --format json` JsonTypeInfo error by changing `Fields` type to `Dictionary&lt;string, JsonElement&gt;` (#116, #115)
+- **Subscriber Export Limits**: Fixed export to include all subscribers by default; added `--limit` option to restrict (#116, #114)
+- **State Filtering**: Fixed cancelled subscriber queries by applying state filter server-side via API parameter (#116, #113)
+- **Form/Segment Subscriber Parsing**: Corrected response type handling for form and segment subscriber queries (#116, #112)</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Visual Studio C# settings -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,40 @@
+#### 1.3.0 January 6th 2026 ####
+
+**New Features:**
+- **Account Analytics**: Added `kit account stats` command for aggregate email statistics (#117, #102)
+  - View total sent, opened, and clicked counts
+  - Display engagement rates (open rate, click rate)
+  - Shows tracking status (open/click tracking enabled)
+  - Supports table, JSON, and CSV output formats
+
+- **Top Broadcast Analysis**: Added `kit broadcast top` command to identify best-performing broadcasts (#118, #61)
+  - Rank broadcasts by metric: opens, clicks, or engagement score
+  - Engagement scoring: `(OpenRate * 0.6) + (ClickRate * 0.4)`
+  - Configurable time range with `--days` (default: 30)
+  - Limit results with `--limit` (default: 10)
+  - Export capabilities with progress indicators
+
+- **Subscriber Engagement Scoring**: Added `kit subscriber scores` command for calculating engagement scores (#119, #63)
+  - Multiple scoring algorithms: weighted (default), tags, maturity
+  - Weighted algorithm balances tag engagement (50 pts), account maturity (30 pts), and active status (20 pts)
+  - Tags algorithm: pure tag-based scoring (10 points per tag, max 100)
+  - Maturity algorithm: account age focused (80 points at 365+ days + 20 for active)
+  - Filter by segment and customize result limits
+  - Export with multiple output formats
+
+- **Cold Subscriber Detection**: Added `kit subscribers cold` command to find disengaged subscribers (#120, #64)
+  - Uses proxy signals: account age + tag count to identify cold subscribers
+  - Configurable thresholds: `--min-days-old` (default: 90) and `--max-tags` (default: 2)
+  - `--was-active` filter for previously-engaged subscribers
+  - Engagement tier breakdown and export capabilities
+  - Helps identify subscribers for re-engagement campaigns or list cleanup
+
+**Bug Fixes:**
+- **JSON Serialization**: Fixed `subscriber list --format json` JsonTypeInfo error by changing `Fields` type to `Dictionary<string, JsonElement>` (#116, #115)
+- **Subscriber Export Limits**: Fixed export to include all subscribers by default; added `--limit` option to restrict (#116, #114)
+- **State Filtering**: Fixed cancelled subscriber queries by applying state filter server-side via API parameter (#116, #113)
+- **Form/Segment Subscriber Parsing**: Corrected response type handling for form and segment subscriber queries (#116, #112)
+
 #### 1.2.0 January 6th 2026 ####
 
 **New Features:**


### PR DESCRIPTION
## Summary
Prepares release v1.3.0 with updated release notes and version metadata.

## Changes in v1.3.0

**New Features:**
- Account analytics command for aggregate email statistics (#117, #102)
- Top broadcast analysis to identify best-performing broadcasts (#118, #61)
- Subscriber engagement scoring with multiple algorithms (#119, #63)
- Cold subscriber detection for re-engagement campaigns (#120, #64)

**Bug Fixes:**
- JSON serialization error in subscriber list command (#116, #115)
- Subscriber export limits now default to all subscribers (#116, #114)
- State filtering applied server-side for accurate results (#116, #113)
- Form/segment subscriber parsing corrected (#116, #112)

## Release Workflow
After this PR merges:
1. Tag will be created from dev branch: `1.3.0`
2. Tag push will trigger GitHub Actions to create the release
3. CI/CD will handle publishing to NuGet and other distribution channels