### PR TITLE
fix: Correct JSON deserialization for subscriber email search

### DIFF
--- a/src/KitCLI.Tests/Services/KitApiClientTests.cs
+++ b/src/KitCLI.Tests/Services/KitApiClientTests.cs
@@ -392,4 +392,128 @@ public class KitApiClientTests
         result.Data[0].EmailAddress.Should().Be("seg1@example.com");
         result.Pagination!.HasNextPage.Should().BeFalse();
     }
+
+    /// <summary>
+    /// Regression test for #124: subscriber search --email not finding subscribers.
+    /// GetSubscriberByEmailAsync must use SubscribersResponse type (not PaginatedResponse)
+    /// to correctly parse the Kit v4 API response format {"subscribers": [...]}.
+    /// </summary>
+    [Fact]
+    public async Task GetSubscriberByEmailAsync_Should_Parse_Response_Correctly()
+    {
+        // Arrange - Kit V4 API returns {"subscribers": [...], "pagination": {...}}
+        var testEmail = "test@example.com";
+        var responseData = new SubscribersResponse
+        {
+            Subscribers = new[]
+            {
+                new Subscriber
+                {
+                    Id = 12345,
+                    EmailAddress = testEmail,
+                    FirstName = "Test",
+                    State = "active"
+                }
+            },
+            Pagination = new PaginationInfo { HasNextPage = false }
+        };
+
+        var json = JsonSerializer.Serialize(responseData, KitJsonContext.Default.SubscribersResponse);
+
+        _mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(json, Encoding.UTF8, "application/json")
+            });
+
+        // Act
+        var result = await _client.GetSubscriberByEmailAsync(testEmail);
+
+        // Assert - this was returning null in #124 due to incorrect response type
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(12345);
+        result.EmailAddress.Should().Be(testEmail);
+        result.FirstName.Should().Be("Test");
+        result.State.Should().Be("active");
+    }
+
+    /// <summary>
+    /// Test that GetSubscriberByEmailAsync handles case-insensitive email matching.
+    /// </summary>
+    [Fact]
+    public async Task GetSubscriberByEmailAsync_Should_Match_Email_Case_Insensitively()
+    {
+        // Arrange
+        var responseData = new SubscribersResponse
+        {
+            Subscribers = new[]
+            {
+                new Subscriber
+                {
+                    Id = 12345,
+                    EmailAddress = "TEST@EXAMPLE.COM",
+                    State = "active"
+                }
+            },
+            Pagination = new PaginationInfo { HasNextPage = false }
+        };
+
+        var json = JsonSerializer.Serialize(responseData, KitJsonContext.Default.SubscribersResponse);
+
+        _mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(json, Encoding.UTF8, "application/json")
+            });
+
+        // Act - search with lowercase
+        var result = await _client.GetSubscriberByEmailAsync("test@example.com");
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.EmailAddress.Should().Be("TEST@EXAMPLE.COM");
+    }
+
+    /// <summary>
+    /// Test that GetSubscriberByEmailAsync returns null when no matching email found.
+    /// </summary>
+    [Fact]
+    public async Task GetSubscriberByEmailAsync_Should_Return_Null_When_Not_Found()
+    {
+        // Arrange
+        var responseData = new SubscribersResponse
+        {
+            Subscribers = Array.Empty<Subscriber>(),
+            Pagination = new PaginationInfo { HasNextPage = false }
+        };
+
+        var json = JsonSerializer.Serialize(responseData, KitJsonContext.Default.SubscribersResponse);
+
+        _mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(json, Encoding.UTF8, "application/json")
+            });
+
+        // Act
+        var result = await _client.GetSubscriberByEmailAsync("nonexistent@example.com");
+
+        // Assert
+        result.Should().BeNull();
+    }
 }

--- a/src/KitCLI/Commands/SubscriberCommands.cs
+++ b/src/KitCLI/Commands/SubscriberCommands.cs
@@ -129,6 +129,7 @@ public static class SubscriberCommands
         }
 
         string? query = null;
+        string? email = null;
         string? status = null;
         string format = "table";
 
@@ -141,6 +142,14 @@ public static class SubscriberCommands
                     if (i + 1 < args.Length)
                     {
                         query = args[++i];
+                    }
+
+                    break;
+                case "--email":
+                case "-e":
+                    if (i + 1 < args.Length)
+                    {
+                        email = args[++i];
                     }
 
                     break;
@@ -171,11 +180,12 @@ public static class SubscriberCommands
             }
         }
 
-        if (string.IsNullOrEmpty(query) && string.IsNullOrEmpty(status))
+        if (string.IsNullOrEmpty(query) && string.IsNullOrEmpty(status) && string.IsNullOrEmpty(email))
         {
             Console.WriteLine("Usage: kit subscriber search [query] [options]");
             Console.WriteLine("Options:");
-            Console.WriteLine("  --query, -q <text>    Search query");
+            Console.WriteLine("  --email, -e <email>   Search by exact email address");
+            Console.WriteLine("  --query, -q <text>    Search query (searches name, email, tags)");
             Console.WriteLine("  --status, -s <state>  Filter by status");
             Console.WriteLine("  --format, -f <format> Output format");
             return 1;
@@ -183,17 +193,36 @@ public static class SubscriberCommands
 
         using var progress = new ProgressIndicator("Searching subscribers");
 
-        // For now, we'll fetch and filter client-side
-        // In a real implementation, we'd use the API's search endpoint
-        var response = await client.GetSubscribersAsync(100);
-        var subscribers = response.Data;
-
-        if (!string.IsNullOrEmpty(status))
+        // If searching by email, use the direct email lookup
+        if (!string.IsNullOrEmpty(email))
         {
-            subscribers = subscribers.Where(s =>
-                s.State.Equals(status, StringComparison.OrdinalIgnoreCase)).ToArray();
+            var subscriber = await client.GetSubscriberByEmailAsync(email);
+            progress.Complete($"Found {(subscriber != null ? 1 : 0)} matching subscribers");
+
+            if (subscriber == null)
+            {
+                Console.WriteLine("No subscribers found matching your search criteria.");
+                return 0;
+            }
+
+            // Fetch tags for the subscriber
+            var tags = await client.GetSubscriberTagsAsync(subscriber.Id);
+            subscriber.Tags = tags;
+
+            OutputFormatter.PrintSubscribers([subscriber], format);
+            return 0;
         }
 
+        // For query-based search, fetch all subscribers and filter client-side
+        var allSubscribers = new List<Subscriber>();
+        await foreach (var subscriber in client.GetAllSubscribersAsync(status))
+        {
+            allSubscribers.Add(subscriber);
+        }
+
+        var subscribers = allSubscribers.ToArray();
+
+        // Filter by query if provided (status is already filtered by the API)
         if (!string.IsNullOrEmpty(query))
         {
             var lowerQuery = query.ToLowerInvariant();

--- a/src/KitCLI/Helpers/CommandHelp.cs
+++ b/src/KitCLI/Helpers/CommandHelp.cs
@@ -207,17 +207,20 @@ public static class CommandHelp
         },
         ["subscriber search"] = new CommandHelpInfo
         {
-            Usage = "kit subscriber search <query> [options]",
-            Description = "Search subscribers by email or name",
+            Usage = "kit subscriber search [query] [options]",
+            Description = "Search subscribers by email address, name, or tags",
             Options = new Dictionary<string, string>
             {
-                ["--limit, -l <number>"] = "Maximum results (default: 50)",
+                ["--email, -e <email>"] = "Search by exact email address (recommended for precise lookup)",
+                ["--query, -q <text>"] = "Search query (searches name, email, tags)",
+                ["--status, -s <status>"] = "Filter by status (active, bounced, cancelled, complained, inactive)",
                 ["--format, -f <format>"] = "Output format (table, json, csv) (default: table)"
             },
             Examples = new[]
             {
+                "kit subscriber search --email user@example.com",
                 "kit subscriber search john",
-                "kit subscriber search @example.com --limit 100"
+                "kit subscriber search --query @example.com --status active"
             }
         },
         ["subscriber stats"] = new CommandHelpInfo

--- a/src/KitCLI/Services/KitApiClient.cs
+++ b/src/KitCLI/Services/KitApiClient.cs
@@ -267,7 +267,7 @@ public sealed class KitApiClient : IKitApiClient, IDisposable
 
     public async Task<Subscriber?> GetSubscriberByEmailAsync(string email, CancellationToken cancellationToken = default)
     {
-        // Kit API doesn't have direct email lookup, so we need to search
+        // Kit v4 API supports email_address query parameter
         var encodedEmail = Uri.EscapeDataString(email);
         var response = await _httpClient.GetAsync($"subscribers?email_address={encodedEmail}", cancellationToken);
 
@@ -277,9 +277,10 @@ public sealed class KitApiClient : IKitApiClient, IDisposable
         }
 
         var json = await response.Content.ReadAsStringAsync(cancellationToken);
-        var result = JsonSerializer.Deserialize(json, KitJsonContext.Default.PaginatedResponseSubscriber);
+        // Kit v4 API returns subscribers wrapped in {"subscribers": [...]}
+        var result = JsonSerializer.Deserialize(json, KitJsonContext.Default.SubscribersResponse);
 
-        return result?.Data.FirstOrDefault(s =>
+        return result?.Subscribers.FirstOrDefault(s =>
             s.EmailAddress.Equals(email, StringComparison.OrdinalIgnoreCase));
     }
 


### PR DESCRIPTION
## Summary
- Fixed `GetSubscriberByEmailAsync` using incorrect response type (`PaginatedResponse<Subscriber>` expects `{"data": [...]}` but Kit v4 API returns `{"subscribers": [...]}`)
- Changed to use `SubscribersResponse` type for correct deserialization
- Added `--email` flag to `subscriber search` command for direct email lookup

Fixes #124

## Test plan
- [x] Added unit tests for `GetSubscriberByEmailAsync`:
  - Parse response correctly
  - Case-insensitive email matching
  - Returns null when not found
- [x] All 124 tests pass
- [x] Manually verified: `kit subscriber search --email jethro@concetto.io` now finds the subscriber