### PR TITLE
feat: Add broadcast write operations (create, update, delete)

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,31 @@ kit broadcast unopened 12345
 # Export broadcasts
 kit broadcast export --output campaigns.csv
 kit broadcast export --all --output all-broadcasts.json
+
+# Create broadcast draft (HTML content from file)
+kit broadcast create --subject "Monthly Newsletter" --content-file newsletter.html
+kit broadcast create --subject "Promo" --content-file promo.html --segment-id 123
+kit broadcast create --subject "Tagged Users" --content-file email.html --tag-id 456
+
+# Create with inline content
+kit broadcast create --subject "Quick Update" --content "<p>Hello!</p>"
+
+# Create with template and preview text
+kit broadcast create --subject "Newsletter" --content-file email.html \
+  --template-id 789 --preview-text "This month's updates..."
+
+# Update broadcast draft
+kit broadcast update 12345 --subject "New Subject"
+kit broadcast update 12345 --content-file updated.html
+kit broadcast update 12345 --segment-id 456 --preview-text "Updated preview"
+
+# Delete broadcast (with confirmation)
+kit broadcast delete 12345
+kit broadcast delete 12345 --force  # Skip confirmation
 ```
+
+> **Note**: Broadcast scheduling is intentionally not supported via CLI for safety.
+> Created broadcasts are always saved as drafts. Use the Kit UI to schedule sending.
 
 ### Tags
 

--- a/src/KitCLI.Tests/Mocks/MockKitApiClient.cs
+++ b/src/KitCLI.Tests/Mocks/MockKitApiClient.cs
@@ -22,6 +22,9 @@ public sealed class MockKitApiClient : IKitApiClient
     public Func<long, CancellationToken, Task<Broadcast?>>? GetBroadcastAsyncFunc { get; set; }
     public Func<long, CancellationToken, Task<BroadcastStats?>>? GetBroadcastStatsAsyncFunc { get; set; }
     public Func<long, CancellationToken, Task<BroadcastClicksResponse?>>? GetBroadcastClicksAsyncFunc { get; set; }
+    public Func<BroadcastCreateRequest, CancellationToken, Task<Broadcast?>>? CreateBroadcastAsyncFunc { get; set; }
+    public Func<long, BroadcastUpdateRequest, CancellationToken, Task<Broadcast?>>? UpdateBroadcastAsyncFunc { get; set; }
+    public Func<long, CancellationToken, Task<bool>>? DeleteBroadcastAsyncFunc { get; set; }
 
     // Tags
     public Func<CancellationToken, Task<Tag[]>>? GetTagsAsyncFunc { get; set; }
@@ -181,6 +184,69 @@ public sealed class MockKitApiClient : IKitApiClient
         }
 
         return Task.FromResult(BroadcastClicks.GetValueOrDefault(broadcastId));
+    }
+
+    public Task<Broadcast?> CreateBroadcastAsync(BroadcastCreateRequest request, CancellationToken cancellationToken = default)
+    {
+        if (CreateBroadcastAsyncFunc != null)
+        {
+            return CreateBroadcastAsyncFunc(request, cancellationToken);
+        }
+
+        var broadcast = new Broadcast
+        {
+            Id = Broadcasts.Count + 1,
+            Subject = request.Subject,
+            Content = request.Content,
+            Description = request.Description,
+            PreviewText = request.PreviewText,
+            IsPublic = request.IsPublic,
+            CreatedAt = DateTime.UtcNow,
+            SubscriberFilter = request.SubscriberFilter
+        };
+        Broadcasts.Add(broadcast);
+        return Task.FromResult<Broadcast?>(broadcast);
+    }
+
+    public Task<Broadcast?> UpdateBroadcastAsync(long id, BroadcastUpdateRequest request, CancellationToken cancellationToken = default)
+    {
+        if (UpdateBroadcastAsyncFunc != null)
+        {
+            return UpdateBroadcastAsyncFunc(id, request, cancellationToken);
+        }
+
+        var broadcast = Broadcasts.FirstOrDefault(b => b.Id == id);
+        if (broadcast == null)
+        {
+            return Task.FromResult<Broadcast?>(null);
+        }
+
+        if (request.Subject != null) broadcast.Subject = request.Subject;
+        if (request.Content != null) broadcast.Content = request.Content;
+        if (request.Description != null) broadcast.Description = request.Description;
+        if (request.PreviewText != null) broadcast.PreviewText = request.PreviewText;
+        if (request.IsPublic.HasValue) broadcast.IsPublic = request.IsPublic.Value;
+        if (request.SubscriberFilter != null) broadcast.SubscriberFilter = request.SubscriberFilter;
+        broadcast.UpdatedAt = DateTime.UtcNow;
+
+        return Task.FromResult<Broadcast?>(broadcast);
+    }
+
+    public Task<bool> DeleteBroadcastAsync(long id, CancellationToken cancellationToken = default)
+    {
+        if (DeleteBroadcastAsyncFunc != null)
+        {
+            return DeleteBroadcastAsyncFunc(id, cancellationToken);
+        }
+
+        var broadcast = Broadcasts.FirstOrDefault(b => b.Id == id);
+        if (broadcast == null)
+        {
+            return Task.FromResult(false);
+        }
+
+        Broadcasts.Remove(broadcast);
+        return Task.FromResult(true);
     }
 
     // Tags

--- a/src/KitCLI.Tests/Mocks/MockKitApiClient.cs
+++ b/src/KitCLI.Tests/Mocks/MockKitApiClient.cs
@@ -221,12 +221,30 @@ public sealed class MockKitApiClient : IKitApiClient
             return Task.FromResult<Broadcast?>(null);
         }
 
-        if (request.Subject != null) broadcast.Subject = request.Subject;
-        if (request.Content != null) broadcast.Content = request.Content;
-        if (request.Description != null) broadcast.Description = request.Description;
-        if (request.PreviewText != null) broadcast.PreviewText = request.PreviewText;
-        if (request.IsPublic.HasValue) broadcast.IsPublic = request.IsPublic.Value;
-        if (request.SubscriberFilter != null) broadcast.SubscriberFilter = request.SubscriberFilter;
+        if (request.Subject != null)
+        {
+            broadcast.Subject = request.Subject;
+        }
+        if (request.Content != null)
+        {
+            broadcast.Content = request.Content;
+        }
+        if (request.Description != null)
+        {
+            broadcast.Description = request.Description;
+        }
+        if (request.PreviewText != null)
+        {
+            broadcast.PreviewText = request.PreviewText;
+        }
+        if (request.IsPublic.HasValue)
+        {
+            broadcast.IsPublic = request.IsPublic.Value;
+        }
+        if (request.SubscriberFilter != null)
+        {
+            broadcast.SubscriberFilter = request.SubscriberFilter;
+        }
         broadcast.UpdatedAt = DateTime.UtcNow;
 
         return Task.FromResult<Broadcast?>(broadcast);

--- a/src/KitCLI/Commands/BroadcastCommands.cs
+++ b/src/KitCLI/Commands/BroadcastCommands.cs
@@ -1940,4 +1940,466 @@ public static class BroadcastCommands
             }
         }
     }
+
+    /// <summary>
+    /// Creates a new broadcast draft. Scheduling is intentionally not supported via CLI for safety.
+    /// </summary>
+    public static async Task<int> HandleCreate(string[] args, IKitApiClient client)
+    {
+        string? subject = null;
+        string? contentFile = null;
+        string? content = null;
+        string? description = null;
+        string? previewText = null;
+        long? templateId = null;
+        long? segmentId = null;
+        long? tagId = null;
+        bool isPublic = false;
+        string format = "json";
+
+        for (int i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--subject":
+                case "-s":
+                    if (i + 1 < args.Length)
+                    {
+                        subject = args[++i];
+                    }
+                    break;
+                case "--content-file":
+                case "-c":
+                    if (i + 1 < args.Length)
+                    {
+                        contentFile = args[++i];
+                    }
+                    break;
+                case "--content":
+                    if (i + 1 < args.Length)
+                    {
+                        content = args[++i];
+                    }
+                    break;
+                case "--description":
+                case "-d":
+                    if (i + 1 < args.Length)
+                    {
+                        description = args[++i];
+                    }
+                    break;
+                case "--preview-text":
+                case "-p":
+                    if (i + 1 < args.Length)
+                    {
+                        previewText = args[++i];
+                    }
+                    break;
+                case "--template-id":
+                case "-t":
+                    if (i + 1 < args.Length && long.TryParse(args[++i], out var tid))
+                    {
+                        templateId = tid;
+                    }
+                    break;
+                case "--segment-id":
+                    if (i + 1 < args.Length && long.TryParse(args[++i], out var sid))
+                    {
+                        segmentId = sid;
+                    }
+                    break;
+                case "--tag-id":
+                    if (i + 1 < args.Length && long.TryParse(args[++i], out var tagid))
+                    {
+                        tagId = tagid;
+                    }
+                    break;
+                case "--public":
+                    isPublic = true;
+                    break;
+                case "--format":
+                case "-f":
+                    if (i + 1 < args.Length)
+                    {
+                        format = args[++i];
+                    }
+                    break;
+            }
+        }
+
+        // Validate required fields
+        if (string.IsNullOrEmpty(subject))
+        {
+            Console.WriteLine("Usage: kit broadcast create --subject <subject> [options]");
+            Console.WriteLine();
+            Console.WriteLine("Required:");
+            Console.WriteLine("  --subject, -s <text>       Email subject line");
+            Console.WriteLine();
+            Console.WriteLine("Content (at least one required):");
+            Console.WriteLine("  --content-file, -c <path>  Path to HTML content file");
+            Console.WriteLine("  --content <html>           Inline HTML content");
+            Console.WriteLine();
+            Console.WriteLine("Options:");
+            Console.WriteLine("  --description, -d <text>   Internal description");
+            Console.WriteLine("  --preview-text, -p <text>  Email preview text");
+            Console.WriteLine("  --template-id, -t <id>     Email template ID");
+            Console.WriteLine("  --segment-id <id>          Target segment ID");
+            Console.WriteLine("  --tag-id <id>              Target tag ID");
+            Console.WriteLine("  --public                   Publish to web");
+            Console.WriteLine("  --format, -f <format>      Output format (json, table)");
+            Console.WriteLine();
+            Console.WriteLine("Note: This creates a DRAFT. Schedule sending via the Kit UI.");
+            return 1;
+        }
+
+        // Get content from file or inline
+        if (!string.IsNullOrEmpty(contentFile))
+        {
+            if (!File.Exists(contentFile))
+            {
+                Console.Error.WriteLine($"Content file not found: {contentFile}");
+                return 1;
+            }
+            content = await File.ReadAllTextAsync(contentFile);
+        }
+
+        if (string.IsNullOrEmpty(content))
+        {
+            Console.Error.WriteLine("Content is required. Use --content-file or --content.");
+            return 1;
+        }
+
+        // Build request
+        var request = new BroadcastCreateRequest
+        {
+            Subject = subject,
+            Content = content,
+            Description = description,
+            PreviewText = previewText,
+            EmailTemplateId = templateId,
+            IsPublic = isPublic
+        };
+
+        // Build subscriber filter if segment or tag specified
+        if (segmentId.HasValue || tagId.HasValue)
+        {
+            var criteria = new List<FilterCriteria>();
+
+            if (segmentId.HasValue)
+            {
+                criteria.Add(new FilterCriteria { Type = "segment", Ids = [segmentId.Value] });
+            }
+
+            if (tagId.HasValue)
+            {
+                criteria.Add(new FilterCriteria { Type = "tag", Ids = [tagId.Value] });
+            }
+
+            request.SubscriberFilter = [new SubscriberFilterGroup { All = criteria.ToArray() }];
+        }
+
+        using var progress = new ProgressIndicator("Creating broadcast draft");
+
+        try
+        {
+            var broadcast = await client.CreateBroadcastAsync(request);
+
+            if (broadcast == null)
+            {
+                progress.Complete("Failed to create broadcast");
+                return 1;
+            }
+
+            progress.Complete($"Created broadcast draft: {broadcast.Id}");
+
+            if (format == "json")
+            {
+                var json = System.Text.Json.JsonSerializer.Serialize(
+                    broadcast,
+                    KitJsonIndentedContext.Default.Broadcast);
+                Console.WriteLine(json);
+            }
+            else
+            {
+                Console.WriteLine();
+                Console.WriteLine($"ID:          {broadcast.Id}");
+                Console.WriteLine($"Subject:     {broadcast.Subject}");
+                Console.WriteLine($"Status:      {broadcast.Status}");
+                Console.WriteLine($"Created:     {broadcast.CreatedAt:yyyy-MM-dd HH:mm:ss}");
+                if (!string.IsNullOrEmpty(broadcast.Description))
+                {
+                    Console.WriteLine($"Description: {broadcast.Description}");
+                }
+                Console.WriteLine();
+                Console.WriteLine("To schedule this broadcast, visit the Kit dashboard.");
+            }
+
+            return 0;
+        }
+        catch (HttpRequestException ex)
+        {
+            progress.Complete("Failed");
+            Console.Error.WriteLine($"Error: {ex.Message}");
+            return 1;
+        }
+    }
+
+    /// <summary>
+    /// Updates an existing broadcast draft.
+    /// </summary>
+    public static async Task<int> HandleUpdate(string[] args, IKitApiClient client)
+    {
+        if (args.Length < 1)
+        {
+            Console.WriteLine("Usage: kit broadcast update <id> [options]");
+            Console.WriteLine();
+            Console.WriteLine("Options:");
+            Console.WriteLine("  --subject, -s <text>       New subject line");
+            Console.WriteLine("  --content-file, -c <path>  New HTML content from file");
+            Console.WriteLine("  --content <html>           New inline HTML content");
+            Console.WriteLine("  --description, -d <text>   New description");
+            Console.WriteLine("  --preview-text, -p <text>  New preview text");
+            Console.WriteLine("  --template-id, -t <id>     New template ID");
+            Console.WriteLine("  --segment-id <id>          Target segment ID");
+            Console.WriteLine("  --tag-id <id>              Target tag ID");
+            Console.WriteLine("  --public                   Publish to web");
+            Console.WriteLine("  --format, -f <format>      Output format (json, table)");
+            return 1;
+        }
+
+        if (!long.TryParse(args[0], out var id))
+        {
+            Console.Error.WriteLine("Invalid broadcast ID. Please provide a numeric ID.");
+            return 1;
+        }
+
+        string? subject = null;
+        string? contentFile = null;
+        string? content = null;
+        string? description = null;
+        string? previewText = null;
+        long? templateId = null;
+        long? segmentId = null;
+        long? tagId = null;
+        bool? isPublic = null;
+        string format = "json";
+
+        for (int i = 1; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--subject":
+                case "-s":
+                    if (i + 1 < args.Length)
+                    {
+                        subject = args[++i];
+                    }
+                    break;
+                case "--content-file":
+                case "-c":
+                    if (i + 1 < args.Length)
+                    {
+                        contentFile = args[++i];
+                    }
+                    break;
+                case "--content":
+                    if (i + 1 < args.Length)
+                    {
+                        content = args[++i];
+                    }
+                    break;
+                case "--description":
+                case "-d":
+                    if (i + 1 < args.Length)
+                    {
+                        description = args[++i];
+                    }
+                    break;
+                case "--preview-text":
+                case "-p":
+                    if (i + 1 < args.Length)
+                    {
+                        previewText = args[++i];
+                    }
+                    break;
+                case "--template-id":
+                case "-t":
+                    if (i + 1 < args.Length && long.TryParse(args[++i], out var tid))
+                    {
+                        templateId = tid;
+                    }
+                    break;
+                case "--segment-id":
+                    if (i + 1 < args.Length && long.TryParse(args[++i], out var sid))
+                    {
+                        segmentId = sid;
+                    }
+                    break;
+                case "--tag-id":
+                    if (i + 1 < args.Length && long.TryParse(args[++i], out var tagid))
+                    {
+                        tagId = tagid;
+                    }
+                    break;
+                case "--public":
+                    isPublic = true;
+                    break;
+                case "--format":
+                case "-f":
+                    if (i + 1 < args.Length)
+                    {
+                        format = args[++i];
+                    }
+                    break;
+            }
+        }
+
+        // Get content from file if specified
+        if (!string.IsNullOrEmpty(contentFile))
+        {
+            if (!File.Exists(contentFile))
+            {
+                Console.Error.WriteLine($"Content file not found: {contentFile}");
+                return 1;
+            }
+            content = await File.ReadAllTextAsync(contentFile);
+        }
+
+        // Build request with only specified fields
+        var request = new BroadcastUpdateRequest
+        {
+            Subject = subject,
+            Content = content,
+            Description = description,
+            PreviewText = previewText,
+            EmailTemplateId = templateId,
+            IsPublic = isPublic
+        };
+
+        // Build subscriber filter if segment or tag specified
+        if (segmentId.HasValue || tagId.HasValue)
+        {
+            var criteria = new List<FilterCriteria>();
+
+            if (segmentId.HasValue)
+            {
+                criteria.Add(new FilterCriteria { Type = "segment", Ids = [segmentId.Value] });
+            }
+
+            if (tagId.HasValue)
+            {
+                criteria.Add(new FilterCriteria { Type = "tag", Ids = [tagId.Value] });
+            }
+
+            request.SubscriberFilter = [new SubscriberFilterGroup { All = criteria.ToArray() }];
+        }
+
+        using var progress = new ProgressIndicator($"Updating broadcast {id}");
+
+        try
+        {
+            var broadcast = await client.UpdateBroadcastAsync(id, request);
+
+            if (broadcast == null)
+            {
+                progress.Complete($"Broadcast not found: {id}");
+                return 1;
+            }
+
+            progress.Complete($"Updated broadcast: {broadcast.Id}");
+
+            if (format == "json")
+            {
+                var json = System.Text.Json.JsonSerializer.Serialize(
+                    broadcast,
+                    KitJsonIndentedContext.Default.Broadcast);
+                Console.WriteLine(json);
+            }
+            else
+            {
+                Console.WriteLine();
+                Console.WriteLine($"ID:          {broadcast.Id}");
+                Console.WriteLine($"Subject:     {broadcast.Subject}");
+                Console.WriteLine($"Status:      {broadcast.Status}");
+                Console.WriteLine($"Updated:     {broadcast.UpdatedAt:yyyy-MM-dd HH:mm:ss}");
+            }
+
+            return 0;
+        }
+        catch (HttpRequestException ex)
+        {
+            progress.Complete("Failed");
+            Console.Error.WriteLine($"Error: {ex.Message}");
+            return 1;
+        }
+    }
+
+    /// <summary>
+    /// Deletes a broadcast draft.
+    /// </summary>
+    public static async Task<int> HandleDelete(string[] args, IKitApiClient client)
+    {
+        if (args.Length < 1)
+        {
+            Console.WriteLine("Usage: kit broadcast delete <id> [--force]");
+            Console.WriteLine();
+            Console.WriteLine("Options:");
+            Console.WriteLine("  --force, -f    Skip confirmation prompt");
+            return 1;
+        }
+
+        if (!long.TryParse(args[0], out var id))
+        {
+            Console.Error.WriteLine("Invalid broadcast ID. Please provide a numeric ID.");
+            return 1;
+        }
+
+        bool force = args.Contains("--force") || args.Contains("-f");
+
+        // Fetch broadcast first to show what we're deleting
+        var broadcast = await client.GetBroadcastAsync(id);
+        if (broadcast == null)
+        {
+            Console.Error.WriteLine($"Broadcast not found: {id}");
+            return 1;
+        }
+
+        // Warn if not a draft
+        if (broadcast.Status != "draft")
+        {
+            Console.WriteLine($"Warning: This broadcast has status '{broadcast.Status}'");
+        }
+
+        if (!force)
+        {
+            Console.WriteLine($"About to delete broadcast:");
+            Console.WriteLine($"  ID:      {broadcast.Id}");
+            Console.WriteLine($"  Subject: {broadcast.Subject}");
+            Console.WriteLine($"  Status:  {broadcast.Status}");
+            Console.WriteLine();
+            Console.Write("Are you sure you want to delete this broadcast? [y/N] ");
+
+            var response = Console.ReadLine();
+            if (!response?.Trim().Equals("y", StringComparison.OrdinalIgnoreCase) ?? true)
+            {
+                Console.WriteLine("Cancelled.");
+                return 0;
+            }
+        }
+
+        using var progress = new ProgressIndicator($"Deleting broadcast {id}");
+
+        var success = await client.DeleteBroadcastAsync(id);
+
+        if (success)
+        {
+            progress.Complete($"Deleted broadcast: {id}");
+            return 0;
+        }
+        else
+        {
+            progress.Complete($"Failed to delete broadcast: {id}");
+            return 1;
+        }
+    }
 }

--- a/src/KitCLI/KitJsonContext.cs
+++ b/src/KitCLI/KitJsonContext.cs
@@ -27,6 +27,8 @@ namespace KitCLI;
 [JsonSerializable(typeof(SimplePaginatedResponse<Broadcast>))]
 [JsonSerializable(typeof(BroadcastsResponse))]
 [JsonSerializable(typeof(BroadcastResponse))]
+[JsonSerializable(typeof(BroadcastCreateRequest))]
+[JsonSerializable(typeof(BroadcastUpdateRequest))]
 [JsonSerializable(typeof(BroadcastStats))]
 [JsonSerializable(typeof(BroadcastStats[]))]
 [JsonSerializable(typeof(BroadcastStatsResponse))]

--- a/src/KitCLI/Models/Broadcast.cs
+++ b/src/KitCLI/Models/Broadcast.cs
@@ -2,6 +2,135 @@ using System.Text.Json.Serialization;
 
 namespace KitCLI.Models;
 
+/// <summary>
+/// Request body for creating a new broadcast draft.
+/// Note: We intentionally omit send_at to ensure broadcasts are always created as drafts.
+/// Scheduling should be done through the Kit UI for safety.
+/// </summary>
+public sealed class BroadcastCreateRequest
+{
+    /// <summary>
+    /// The HTML content of the email body.
+    /// </summary>
+    [JsonPropertyName("content")]
+    public string Content { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The subject line of the broadcast.
+    /// </summary>
+    [JsonPropertyName("subject")]
+    public string Subject { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Optional description for internal reference.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Optional preview text shown before opening the email.
+    /// </summary>
+    [JsonPropertyName("preview_text")]
+    public string? PreviewText { get; set; }
+
+    /// <summary>
+    /// Optional email template ID. Uses account default if not specified.
+    /// </summary>
+    [JsonPropertyName("email_template_id")]
+    public long? EmailTemplateId { get; set; }
+
+    /// <summary>
+    /// Optional sending email address. Uses account default if not specified.
+    /// </summary>
+    [JsonPropertyName("email_address")]
+    public string? EmailAddress { get; set; }
+
+    /// <summary>
+    /// Whether to publish to web. Defaults to false.
+    /// </summary>
+    [JsonPropertyName("public")]
+    public bool IsPublic { get; set; }
+
+    /// <summary>
+    /// Optional thumbnail URL for web publishing.
+    /// </summary>
+    [JsonPropertyName("thumbnail_url")]
+    public string? ThumbnailUrl { get; set; }
+
+    /// <summary>
+    /// Optional thumbnail alt text.
+    /// </summary>
+    [JsonPropertyName("thumbnail_alt")]
+    public string? ThumbnailAlt { get; set; }
+
+    /// <summary>
+    /// Optional subscriber filter for targeting specific segments or tags.
+    /// </summary>
+    [JsonPropertyName("subscriber_filter")]
+    public SubscriberFilterGroup[]? SubscriberFilter { get; set; }
+}
+
+/// <summary>
+/// Request body for updating an existing broadcast.
+/// Only non-null fields will be updated.
+/// </summary>
+public sealed class BroadcastUpdateRequest
+{
+    /// <summary>
+    /// The HTML content of the email body.
+    /// </summary>
+    [JsonPropertyName("content")]
+    public string? Content { get; set; }
+
+    /// <summary>
+    /// The subject line of the broadcast.
+    /// </summary>
+    [JsonPropertyName("subject")]
+    public string? Subject { get; set; }
+
+    /// <summary>
+    /// Optional description for internal reference.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Optional preview text shown before opening the email.
+    /// </summary>
+    [JsonPropertyName("preview_text")]
+    public string? PreviewText { get; set; }
+
+    /// <summary>
+    /// Optional email template ID.
+    /// </summary>
+    [JsonPropertyName("email_template_id")]
+    public long? EmailTemplateId { get; set; }
+
+    /// <summary>
+    /// Whether to publish to web.
+    /// </summary>
+    [JsonPropertyName("public")]
+    public bool? IsPublic { get; set; }
+
+    /// <summary>
+    /// Optional thumbnail URL for web publishing.
+    /// </summary>
+    [JsonPropertyName("thumbnail_url")]
+    public string? ThumbnailUrl { get; set; }
+
+    /// <summary>
+    /// Optional thumbnail alt text.
+    /// </summary>
+    [JsonPropertyName("thumbnail_alt")]
+    public string? ThumbnailAlt { get; set; }
+
+    /// <summary>
+    /// Optional subscriber filter for targeting specific segments or tags.
+    /// </summary>
+    [JsonPropertyName("subscriber_filter")]
+    public SubscriberFilterGroup[]? SubscriberFilter { get; set; }
+}
+
 public sealed class Broadcast
 {
     [JsonPropertyName("id")]

--- a/src/KitCLI/Program.cs
+++ b/src/KitCLI/Program.cs
@@ -547,6 +547,7 @@ static async Task<int> HandleBroadcastCommand(string[] args, bool isReadOnly)
 
     return args[0].ToLowerInvariant() switch
     {
+        // Read operations
         "list" => await BroadcastCommands.HandleList(args[1..], client),
         "get" => await BroadcastCommands.HandleGet(args[1..], client),
         "stats" => await BroadcastCommands.HandleStats(args[1..], client),
@@ -559,6 +560,10 @@ static async Task<int> HandleBroadcastCommand(string[] args, bool isReadOnly)
         "compare" => await BroadcastCommands.HandleCompare(args[1..], client),
         "top" => await BroadcastCommands.HandleTop(args[1..], client),
         "export" => await BroadcastCommands.HandleExport(args[1..], client),
+        // Write operations (draft only - no scheduling)
+        "create" => isReadOnly ? ShowReadOnlyError("broadcast create") : await BroadcastCommands.HandleCreate(args[1..], client),
+        "update" => isReadOnly ? ShowReadOnlyError("broadcast update") : await BroadcastCommands.HandleUpdate(args[1..], client),
+        "delete" => isReadOnly ? ShowReadOnlyError("broadcast delete") : await BroadcastCommands.HandleDelete(args[1..], client),
         _ => ShowUnknownCommand($"broadcast {args[0]}")
     };
 }

--- a/src/KitCLI/Services/KitApiClient.cs
+++ b/src/KitCLI/Services/KitApiClient.cs
@@ -34,6 +34,11 @@ public interface IKitApiClient
     Task<BroadcastStats?> GetBroadcastStatsAsync(long broadcastId, CancellationToken cancellationToken = default);
     Task<BroadcastClicksResponse?> GetBroadcastClicksAsync(long broadcastId, CancellationToken cancellationToken = default);
 
+    // Broadcast write operations (drafts only - no scheduling)
+    Task<Broadcast?> CreateBroadcastAsync(BroadcastCreateRequest request, CancellationToken cancellationToken = default);
+    Task<Broadcast?> UpdateBroadcastAsync(long id, BroadcastUpdateRequest request, CancellationToken cancellationToken = default);
+    Task<bool> DeleteBroadcastAsync(long id, CancellationToken cancellationToken = default);
+
     // Tags
     Task<Tag[]> GetTagsAsync(CancellationToken cancellationToken = default);
     Task<PaginatedResponse<Subscriber>> GetTagSubscribersAsync(
@@ -374,6 +379,90 @@ public sealed class KitApiClient : IKitApiClient, IDisposable
         var json = await response.Content.ReadAsStringAsync(cancellationToken);
         // Kit V4 API returns {"broadcast": {"id": ..., "clicks": [...]}, "pagination": {...}}
         return JsonSerializer.Deserialize(json, KitJsonContext.Default.BroadcastClicksResponse);
+    }
+
+    public async Task<Broadcast?> CreateBroadcastAsync(BroadcastCreateRequest request, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var requestBody = JsonSerializer.Serialize(request, KitJsonContext.Default.BroadcastCreateRequest);
+            var content = new StringContent(requestBody, Encoding.UTF8, "application/json");
+
+            var response = await _httpClient.PostAsync("broadcasts", content, cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorJson = await response.Content.ReadAsStringAsync(cancellationToken);
+                var error = JsonSerializer.Deserialize(errorJson, KitJsonContext.Default.ErrorResponse);
+                throw new HttpRequestException($"Failed to create broadcast: {error?.Message ?? error?.Error ?? response.ReasonPhrase}");
+            }
+
+            var json = await response.Content.ReadAsStringAsync(cancellationToken);
+            var result = JsonSerializer.Deserialize(json, KitJsonContext.Default.BroadcastResponse);
+            return result?.Broadcast;
+        }
+        catch (HttpRequestException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new HttpRequestException($"Failed to create broadcast: {ex.Message}", ex);
+        }
+    }
+
+    public async Task<Broadcast?> UpdateBroadcastAsync(long id, BroadcastUpdateRequest request, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var requestBody = JsonSerializer.Serialize(request, KitJsonContext.Default.BroadcastUpdateRequest);
+            var content = new StringContent(requestBody, Encoding.UTF8, "application/json");
+
+            var response = await _httpClient.PutAsync($"broadcasts/{id}", content, cancellationToken);
+
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorJson = await response.Content.ReadAsStringAsync(cancellationToken);
+                var error = JsonSerializer.Deserialize(errorJson, KitJsonContext.Default.ErrorResponse);
+                throw new HttpRequestException($"Failed to update broadcast: {error?.Message ?? error?.Error ?? response.ReasonPhrase}");
+            }
+
+            var json = await response.Content.ReadAsStringAsync(cancellationToken);
+            var result = JsonSerializer.Deserialize(json, KitJsonContext.Default.BroadcastResponse);
+            return result?.Broadcast;
+        }
+        catch (HttpRequestException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new HttpRequestException($"Failed to update broadcast: {ex.Message}", ex);
+        }
+    }
+
+    public async Task<bool> DeleteBroadcastAsync(long id, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var response = await _httpClient.DeleteAsync($"broadcasts/{id}", cancellationToken);
+
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                return false;
+            }
+
+            return response.IsSuccessStatusCode;
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     public async Task<Tag[]> GetTagsAsync(CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary

Add CLI commands for managing broadcast drafts:

- `kit broadcast create` - Create new broadcast drafts with HTML content
- `kit broadcast update` - Update existing broadcast properties  
- `kit broadcast delete` - Delete broadcasts with confirmation prompt

**Key design decision**: Scheduling is intentionally not exposed via CLI for safety. All broadcasts are created as drafts and must be scheduled through the Kit UI.

## Features

- **Draft-only by design** - No `send_at` parameter, preventing accidental email sends
- **Segment/tag targeting** - `--segment-id` and `--tag-id` options for audience selection
- **Template support** - `--template-id` to use existing email templates
- **HTML content** - Via `--content-file` (recommended) or inline `--content`
- **Preview text** - `--preview-text` for email preview snippet
- **Read-only mode** - Write operations blocked with `--read-only` flag
- **Delete confirmation** - Requires `y/N` prompt unless `--force` is used

## Usage Examples

```bash
# Create broadcast draft from HTML file
kit broadcast create --subject "Monthly Newsletter" --content-file newsletter.html

# Create with segment targeting
kit broadcast create --subject "Promo" --content-file promo.html --segment-id 123

# Update draft
kit broadcast update 12345 --subject "New Subject" --preview-text "Updated preview"

# Delete with confirmation
kit broadcast delete 12345
kit broadcast delete 12345 --force  # Skip confirmation
```

## Test plan

- [x] Create broadcast draft via CLI - verified working
- [x] Update broadcast properties - verified working
- [x] Delete broadcast with confirmation - verified working
- [x] Read-only mode blocks write operations - verified working
- [x] AOT compilation succeeds (12MB binary, within 15MB target)
- [x] Build passes with no warnings

Closes #70