### PR TITLE
chore: Prepare release v1.4.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,41 +8,25 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>1.3.0</VersionPrefix>
+    <VersionPrefix>1.4.0</VersionPrefix>
     <PackageReleaseNotes>**New Features:**
-- **Account Analytics**: Added `kit account stats` command for aggregate email statistics (#117, #102)
-  - View total sent, opened, and clicked counts
-  - Display engagement rates (open rate, click rate)
-  - Shows tracking status (open/click tracking enabled)
-  - Supports table, JSON, and CSV output formats
-
-- **Top Broadcast Analysis**: Added `kit broadcast top` command to identify best-performing broadcasts (#118, #61)
-  - Rank broadcasts by metric: opens, clicks, or engagement score
-  - Engagement scoring: `(OpenRate * 0.6) + (ClickRate * 0.4)`
-  - Configurable time range with `--days` (default: 30)
-  - Limit results with `--limit` (default: 10)
-  - Export capabilities with progress indicators
-
-- **Subscriber Engagement Scoring**: Added `kit subscriber scores` command for calculating engagement scores (#119, #63)
-  - Multiple scoring algorithms: weighted (default), tags, maturity
-  - Weighted algorithm balances tag engagement (50 pts), account maturity (30 pts), and active status (20 pts)
-  - Tags algorithm: pure tag-based scoring (10 points per tag, max 100)
-  - Maturity algorithm: account age focused (80 points at 365+ days + 20 for active)
-  - Filter by segment and customize result limits
-  - Export with multiple output formats
-
-- **Cold Subscriber Detection**: Added `kit subscribers cold` command to find disengaged subscribers (#120, #64)
-  - Uses proxy signals: account age + tag count to identify cold subscribers
-  - Configurable thresholds: `--min-days-old` (default: 90) and `--max-tags` (default: 2)
-  - `--was-active` filter for previously-engaged subscribers
-  - Engagement tier breakdown and export capabilities
-  - Helps identify subscribers for re-engagement campaigns or list cleanup
+- **Broadcast Write Operations**: Added commands for managing broadcast drafts (#126, #70)
+  - `kit broadcast create` - Create new broadcast drafts with HTML content
+  - `kit broadcast update` - Update existing broadcast properties
+  - `kit broadcast delete` - Delete broadcasts with confirmation prompt
+  - Draft-only by design: scheduling intentionally not exposed via CLI for safety
+  - Segment and tag targeting support via `--segment-id` and `--tag-id`
+  - Template support with `--template-id` option
+  - HTML content via `--content-file` (recommended) or inline `--content`
+  - Preview text customization with `--preview-text`
+  - Read-only mode protection via `--read-only` flag
+  - Delete confirmation prompts (skip with `--force`)
 
 **Bug Fixes:**
-- **JSON Serialization**: Fixed `subscriber list --format json` JsonTypeInfo error by changing `Fields` type to `Dictionary&lt;string, JsonElement&gt;` (#116, #115)
-- **Subscriber Export Limits**: Fixed export to include all subscribers by default; added `--limit` option to restrict (#116, #114)
-- **State Filtering**: Fixed cancelled subscriber queries by applying state filter server-side via API parameter (#116, #113)
-- **Form/Segment Subscriber Parsing**: Corrected response type handling for form and segment subscriber queries (#116, #112)</PackageReleaseNotes>
+- **Subscriber Email Search**: Fixed JSON deserialization for `GetSubscriberByEmailAsync` method (#125, #124)
+  - Corrected response type handling for Kit v4 API format (`subscribers` vs `data` field)
+  - Added `--email` flag to `kit subscriber search` command for direct email lookup
+  - Implemented case-insensitive email matching</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Visual Studio C# settings -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,24 @@
+#### 1.4.0 January 9th 2026 ####
+
+**New Features:**
+- **Broadcast Write Operations**: Added commands for managing broadcast drafts (#126, #70)
+  - `kit broadcast create` - Create new broadcast drafts with HTML content
+  - `kit broadcast update` - Update existing broadcast properties
+  - `kit broadcast delete` - Delete broadcasts with confirmation prompt
+  - Draft-only by design: scheduling intentionally not exposed via CLI for safety
+  - Segment and tag targeting support via `--segment-id` and `--tag-id`
+  - Template support with `--template-id` option
+  - HTML content via `--content-file` (recommended) or inline `--content`
+  - Preview text customization with `--preview-text`
+  - Read-only mode protection via `--read-only` flag
+  - Delete confirmation prompts (skip with `--force`)
+
+**Bug Fixes:**
+- **Subscriber Email Search**: Fixed JSON deserialization for `GetSubscriberByEmailAsync` method (#125, #124)
+  - Corrected response type handling for Kit v4 API format (`subscribers` vs `data` field)
+  - Added `--email` flag to `kit subscriber search` command for direct email lookup
+  - Implemented case-insensitive email matching
+
 #### 1.3.0 January 6th 2026 ####
 
 **New Features:**


### PR DESCRIPTION
## Summary

Prepare release v1.4.0 with updated release notes and version metadata.

## Changes

- Updated RELEASE_NOTES.md with v1.4.0 changes
- Updated Directory.Build.props to version 1.4.0
- Included release notes for broadcast write operations and subscriber email search fix

## New in v1.4.0

**New Features:**
- Broadcast write operations (create, update, delete) for managing broadcast drafts
- Draft-only design for safety (no scheduling via CLI)
- Segment/tag targeting, template support, HTML content handling

**Bug Fixes:**
- Fixed JSON deserialization for subscriber email search
- Added `--email` flag to `kit subscriber search` command

## Checklist

- [x] RELEASE_NOTES.md updated with v1.4.0 entry
- [x] Version bumped to 1.4.0 in Directory.Build.props
- [x] Build script executed successfully
- [x] All changes committed to release branch